### PR TITLE
fix sprockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,8 +128,8 @@ RUN chown app Gemfile.lock
 RUN mkdir -p /var/log/nginx/qul.tarteel.ai
 
 # precompile assets
-RUN yarn build:segments
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN yarn build:segments
 
 #TODO: fix this, sprockets can't find the compiled assets.
 #Compiling twice seems to be working


### PR DESCRIPTION
Assets are being compiled but sprockets can't find them for some reason. I guess esbuild is compiling them async? 

Compiling them twice seems to fix the issue.