### PR TITLE
Have same content and order for tools and resources cards on landing page

### DIFF
--- a/app/assets/stylesheets/landing_page/_tool_cards.scss
+++ b/app/assets/stylesheets/landing_page/_tool_cards.scss
@@ -61,10 +61,10 @@ a.tool-card-with-bg {
     width: 100%;
   }
 
-  &.segments, &.recitation {
+  &.segments, &.recitation, &.card-recitations {
    background-image: url("tools-cards/timestamp.webp");
   }
-  &.mushaf-layout, &.page-layout {
+  &.mushaf-layout, &.page-layout, &.card-mushaf-layouts {
     backdrop-filter: brightness(1.2);
     background-image: linear-gradient(rgba(245, 222, 179, 0.3), rgba(0, 0, 0, 0.5)), url("tools-cards/mushaf-layout.webp");
   }

--- a/app/assets/stylesheets/landing_page/_tools.scss
+++ b/app/assets/stylesheets/landing_page/_tools.scss
@@ -61,11 +61,11 @@
   //   margin-inline-end: 30px;
   // }
 
-  .info-tip {
+  /*.info-tip {
     position: absolute !important;
     left: 24px;
     bottom: 32px;
-  }
+  }*/
 
   .cta {
     padding: 4px 10px;

--- a/app/helpers/landing_helper.rb
+++ b/app/helpers/landing_helper.rb
@@ -24,7 +24,6 @@ module LandingHelper
         url: '/resources/mushaf-layout',
         count: total_layout,
         type: 'card-mushaf-layouts',
-        # TODO: once all layout are approved, stats will looks weird. Fix the messaging
         stats: "<div><div>#{approved_layout} Layouts —  Approved</div><div>#{total_layout - approved_layout} Layouts —  WIP</div></div>"
       )
     ]
@@ -56,7 +55,7 @@ module LandingHelper
         type: 'tafsirs',
         stats: "<div><div>#{tafisrs.mukhtasar_tafisr.count} Mukhtasar tafsirs</div><div>#{tafisrs.count - tafisrs.mukhtasar_tafisr.count} Detailed tafsirs</div></div>"
       ),
-      #TODO: use font/text svg and update stats
+      # TODO: use font/text svg and update stats
       ToolCard.new(
         title: "Quran script and fonts",
         description: "Download Quran text and fonts, Madani, IndoPak etc.",
@@ -75,7 +74,7 @@ module LandingHelper
         count: ResourceContent.quran_metadata.count,
         stats: "<div><div>Total resources</div></div>"
       ),
-      #TODO: update bg and svg
+      # TODO: update bg and svg
       ToolCard.new(
         title: "Transliteration",
         description: "Download transliteration data to read the Quranic text in Latin script.",
@@ -138,6 +137,7 @@ module LandingHelper
   end
 
   def featured_developer_tools
+=begin
     [
       ToolCard.new(
         title: 'Surah audio segments',
@@ -194,9 +194,13 @@ module LandingHelper
         info_tip: "This tool enables you to proofread Quran script and rendering in various fonts, examining it both ayah by ayah and word by word. Ensure that the script is accurately rendered and consistent across different fonts.",
       )
     ]
+=end
+
+    developer_tools.first(8)
   end
 
   def featured_developer_resources
+=begin
     [
       ToolCard.new(
         title: 'Download Quran Translation',
@@ -247,5 +251,7 @@ module LandingHelper
         cta_bg: 'rgba(56, 165, 126, 0.9)'
       )
     ]
+=end
+    featured_downloadable_resource_cards + downloadable_resource_cards.first(5)
   end
 end

--- a/app/helpers/tools_helper.rb
+++ b/app/helpers/tools_helper.rb
@@ -69,7 +69,7 @@ module ToolsHelper
         icon: 'open_book.svg',
         tags: ['Quran script', 'Fonts'],
         cta_bg: 'rgba(56, 165, 126, 0.9)',
-        info_tip: "This tool enables you to proofread Quran script and rendering in various fonts, examining it both ayah by ayah and word by word. Ensure that the script is accurately rendered and consistent across different fonts.",
+        info_tip: "This tool enables you to proofread Quran script( For Tashkeel issues and font compatibility), both ayah by ayah and word by word.",
         ),
       ToolCard.new(
         title: 'Surah Info in different languages',
@@ -79,17 +79,17 @@ module ToolsHelper
         icon: 'timestamp.svg',
         tags: ['Surah info'],
         cta_bg: 'rgba(56, 165, 126, 0.9)',
-        info_tip: ""
+        info_tip: "This tool allow you to proofread Surah info in different languages."
       ),
       ToolCard.new(
-        title: 'Arabic/Urdu word by word transliteration',
+        title: 'Arabic/Urdu syllable of Quran words',
         description: 'Transliteration of each word of Quran in Arabic and Urdu.',
         url: arabic_transliterations_path,
         type: 'corpus',
         tags: ['Transliteration', 'Arabic', 'Word by word'],
         icon: 'qaf.svg',
         cta_bg: 'rgba(56, 165, 126, 0.9)',
-        info_tip: ""
+        info_tip: "This tool allow you to prepare Arabic transliterations(syllable)."
       ),
       ToolCard.new(
         title: 'Word by word translation',
@@ -99,7 +99,7 @@ module ToolsHelper
         tags: ['Translation', 'Word by word'],
         icon: 'timestamp.svg',
         cta_bg: 'rgba(56, 165, 126, 0.9)',
-        info_tip: ""
+        info_tip: "This tool is used to proofread and fix word-by-word translations"
       ),
       ToolCard.new(
         title: 'Concordance labeling of each word',
@@ -109,7 +109,7 @@ module ToolsHelper
         tags: ['Corpus', 'Grammar', 'POS', 'Morphology'],
         icon: 'tags.svg',
         cta_bg: 'rgba(56, 165, 126, 0.9)',
-        info_tip: ""
+        info_tip: "This tool is used to tag part of speech, grammar of each word of Quran."
       ),
       ToolCard.new(
         title: 'Text unicode value',
@@ -119,7 +119,7 @@ module ToolsHelper
         tags: ['Letter info'],
         icon: 'info.svg',
         cta_bg: 'rgba(56, 165, 126, 0.9)',
-        info_tip: ""
+        info_tip: "This tool helps you detect unicode value of any character, and is being used to debug the font issues."
       )
     ]
   end

--- a/app/views/landing/_resources.html.erb
+++ b/app/views/landing/_resources.html.erb
@@ -2,37 +2,72 @@
   <h4>Developer Resources</h4>
 </div>
 <div class="tools-container mt-4 gap-3 gap-md-4">
-  <% featured_developer_resources.each do |tool| %>
-    <a href="<%= tool.url %>">
-      <div class="tool-card tool-card-with-bg <%= tool.type %>">
-        <div class="overlay"></div>
-        <div>
-          <h5><%= tool.title %></h5>
-          <p class="info">
-            <%= tool.description %>
-          </p>
-        </div>
+  <% featured_developer_resources.each do |card| %>
+    <% if false %>
+      <a href="<%= tool.url %>">
+        <div class="tool-card tool-card-with-bg <%= tool.type %>">
+          <div class="overlay"></div>
+          <div>
+            <h5><%= tool.title %></h5>
+            <p class="info">
+              <%= tool.description %>
+            </p>
+          </div>
 
-        <div class="cta" style="background: <%= tool.cta_bg %>;">
+          <div class="cta" style="background: <%= tool.cta_bg %>;">
           <span>
             Learn more
           </span>
-        </div>
-
-        <div class="icon">
-          <%= image_tag "card-icon/#{tool.icon}" %>
-        </div>
-
-        <% if tool.info_tip %>
-          <div class="info d-flex">
-            <svg
-              title="<%= tool.info_tip %>"
-              data-controller="tooltip"
-              width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M12 0.660217C5.376 0.660217 0 6.03622 0 12.6602C0 19.2842 5.376 24.6602 12 24.6602C18.624 24.6602 24 19.2842 24 12.6602C24 6.03622 18.624 0.660217 12 0.660217ZM13.2 18.6602H10.8V11.4602H13.2V18.6602ZM13.2 9.06022H10.8V6.66022H13.2V9.06022Z" fill="white"/>
-            </svg>
           </div>
-        <% end %>
+
+          <div class="icon">
+            <%= image_tag "card-icon/#{tool.icon}" %>
+          </div>
+
+          <% if tool.info_tip %>
+            <div class="info d-flex">
+              <svg
+                title="<%= tool.info_tip %>"
+                data-controller="tooltip"
+                width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 0.660217C5.376 0.660217 0 6.03622 0 12.6602C0 19.2842 5.376 24.6602 12 24.6602C18.624 24.6602 24 19.2842 24 12.6602C24 6.03622 18.624 0.660217 12 0.660217ZM13.2 18.6602H10.8V11.4602H13.2V18.6602ZM13.2 9.06022H10.8V6.66022H13.2V9.06022Z" fill="white"/>
+              </svg>
+            </div>
+          <% end %>
+        </div>
+      </a>
+    <% end %>
+
+    <a href="<%= card.url %>">
+      <div class="resource-card tool-card tool-card-with-bg  <%= card.type %>">
+        <div class="overlay"></div>
+        <div class="p-4 h-100 d-flex flex-column justify-content-between">
+          <div>
+            <h5>
+              <%= card.title %>
+            </h5>
+
+            <p class="info">
+              <%= card.description %>
+            </p>
+          </div>
+
+          <div class="icon">
+            <%= image_tag "card-icon/#{card.icon}" %>
+          </div>
+
+          <div class="d-flex align-items-center justify-content-between">
+            <% if card.count.to_i > 0 %>
+              <div class="text-white fw-bold">
+                <%= card.stats.to_s.html_safe %>
+              </div>
+
+              <div class="featured-count-badge">
+                <%= card.count %>
+              </div>
+            <% end %>
+          </div>
+        </div>
       </div>
     </a>
   <% end %>

--- a/app/views/landing/_tools.html.erb
+++ b/app/views/landing/_tools.html.erb
@@ -1,38 +1,87 @@
+<%
+  patterns = (1..10).to_a
+%>
 <div class="container-lg">
   <h4>Developer Tools</h4>
 </div>
 
-<div class="tools-container mt-4 mt-md-8 gap-3 gap-md-4">
+<div class="tools-container  mt-4 mt-md-8 gap-3 gap-md-4">
   <% featured_developer_tools.each do |tool| %>
-    <a href="<%= tool.url %>">
-      <div class="tool-card tool-card-with-bg position-relative <%= tool.type %>">
-        <div class="overlay"></div>
-        <div>
-          <h5>
-            <%= tool.title %>
-          </h5>
-          <p class="info">
-            <%= tool.description %>
-          </p>
-        </div>
+    <% if false %>
+      <a href="<%= tool.url %>">
+        <div class="tool-card tool-card-with-bg position-relative <%= tool.type %>">
+          <div class="overlay"></div>
+          <div>
+            <h5>
+              <%= tool.title %>
+            </h5>
+            <p class="info">
+              <%= tool.description %>
+            </p>
+          </div>
 
-        <div class="cta" style="background: <%= tool.cta_bg %>;">
+          <div class="cta" style="background: <%= tool.cta_bg %>;">
           <span>
             Learn more
           </span>
-        </div>
+          </div>
 
-        <div class="icon">
-          <%= image_tag "card-icon/#{tool.icon}" %>
-        </div>
+          <div class="icon">
+            <%= image_tag "card-icon/#{tool.icon}" %>
+          </div>
 
-        <div class="info-tip">
-          <svg
-            title="<%= tool.info_tip %>"
-            data-controller="tooltip"
-            width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M12 0.660217C5.376 0.660217 0 6.03622 0 12.6602C0 19.2842 5.376 24.6602 12 24.6602C18.624 24.6602 24 19.2842 24 12.6602C24 6.03622 18.624 0.660217 12 0.660217ZM13.2 18.6602H10.8V11.4602H13.2V18.6602ZM13.2 9.06022H10.8V6.66022H13.2V9.06022Z" fill="white"/>
-          </svg>
+          <div class="info-tip">
+            <svg
+              title="<%= tool.info_tip %>"
+              data-controller="tooltip"
+              width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 0.660217C5.376 0.660217 0 6.03622 0 12.6602C0 19.2842 5.376 24.6602 12 24.6602C18.624 24.6602 24 19.2842 24 12.6602C24 6.03622 18.624 0.660217 12 0.660217ZM13.2 18.6602H10.8V11.4602H13.2V18.6602ZM13.2 9.06022H10.8V6.66022H13.2V9.06022Z" fill="white"/>
+            </svg>
+          </div>
+        </div>
+      </a>
+    <% end %>
+
+    <a href="<%= tool.url %>">
+      <div class="resource-card tool-card tool-card-with-bg position-relative pattern<%= patterns.sample %>">
+        <div class="overlay"></div>
+        <div class="p-4 h-100 d-flex flex-column justify-content-between">
+          <div>
+            <h5>
+              <%= tool.title %>
+            </h5>
+
+            <p class="info">
+              <%= tool.description %>
+            </p>
+          </div>
+
+          <div class="cta" style="background: <%= tool.cta_bg %>; width: 105px">
+            <span>Learn more</span>
+          </div>
+
+          <div class="icon">
+            <%= image_tag "card-icon/#{tool.icon}" %>
+          </div>
+
+          <div class="d-flex justify-content-between">
+            <div>
+              <% tool.tags.each do |tag| %>
+                <span class="badge <%= resource_tag_class(tag.strip) %>">
+                  <%= tag %>
+                </span>
+              <% end %>
+            </div>
+
+            <div class="info-tip">
+              <svg
+                title="<%= tool.info_tip %>"
+                data-controller="tooltip"
+                width="24" height="25" viewBox="0 0 24 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M12 0.660217C5.376 0.660217 0 6.03622 0 12.6602C0 19.2842 5.376 24.6602 12 24.6602C18.624 24.6602 24 19.2842 24 12.6602C24 6.03622 18.624 0.660217 12 0.660217ZM13.2 18.6602H10.8V11.4602H13.2V18.6602ZM13.2 9.06022H10.8V6.66022H13.2V9.06022Z" fill="white"/>
+              </svg>
+            </div>
+          </div>
         </div>
       </div>
     </a>


### PR DESCRIPTION

| # | Before | New |
|--------|--------|--------|
| Tools | ![image](https://github.com/user-attachments/assets/987ad708-d3b5-49df-aa39-15c0e0ba4c4a) | ![image](https://github.com/user-attachments/assets/608a6a63-505e-4167-905f-01d73c41dab7) |
| Resources | ![image](https://github.com/user-attachments/assets/fc415d81-ae60-4193-9bc3-3c9b412e8ab3) | ![image](https://github.com/user-attachments/assets/2a3a5f29-9ef7-466e-b9b4-079e8f5ab6cf)|




