### PR TITLE
Fix FAQ question wrapping issue

### DIFF
--- a/app/assets/stylesheets/components/_faq.scss
+++ b/app/assets/stylesheets/components/_faq.scss
@@ -12,6 +12,7 @@
       height: 1.6rem;
       background-color: $primary;
       border-radius: 50%;
+      flex-shrink: 0;
       transition: transform 0.2s cubic-bezier(0.4, 0.0, 0.2, 1);
 
       &:after, &:before {
@@ -32,8 +33,12 @@
     }
 
     .question {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
       color: $gray-700;
       text-decoration: none;
+      gap: 1rem;
 
       &:hover {
         color: $primary;

--- a/app/views/community/faq.html.erb
+++ b/app/views/community/faq.html.erb
@@ -32,7 +32,7 @@
     <div class="mt-3 mt-md-4 faq" data-controller="faq">
       <% @items.each do |faq| %>
         <div class="item">
-          <a href="#_" class="question flex-between py-4">
+          <a href="#_" class="question py-4">
             <span class="h5">
               <%= faq.question.html_safe %>
             </span>


### PR DESCRIPTION
Fixes the wrapping issue we are seeing on the FAQ page on smaller widths:
![2024-09-23 at 12 39 16@2x](https://github.com/user-attachments/assets/57d5f945-ded6-4bcf-90aa-eb3d30bc4e94)
