### PR TITLE
Fix auto play action for segments tool

### DIFF
--- a/app/javascript/segments/components/ActionBar.vue
+++ b/app/javascript/segments/components/ActionBar.vue
@@ -29,7 +29,8 @@
                 id="toggle-hotkeys"
             />
             <label for="toggle-hotkeys"
-                   class="mx-2 has-tooltip"
+                   class="mx-2"
+                   data-controller="tooltip"
                    title="Toggle hotkeys">
               Hotkeys
             </label>
@@ -43,7 +44,7 @@
                 id="toggle-segments"
             />
             <label for="toggle-segments"
-                   class="mx-2 has-tooltip"
+                   class="mx-2"
                    title="Toggle segments table.">
               Segments
             </label>
@@ -57,7 +58,8 @@
                 id="toggle-scroll"
             />
             <label for="toggle-scroll"
-                   class="mx-2 has-tooltip"
+                   class="mx-2"
+                   data-controller="tooltip"
                    title="Autoscroll segments table to current word">
               Autoscroll
             </label>
@@ -102,27 +104,12 @@
             :checked="lockAyah"
             @change="toggleLockAyah"
             id="lock-ayah"
-            :disabled="segmentLocked"
         />
         <label for="lock-ayah"
-               class="mx-2 has-tooltip"
+               class="mx-2"
+               data-controller="tooltip"
                title="If checked, player will not play the next ayah when current ayah is finished.">
           Lock ayah
-        </label>
-        <input
-            v-if="lockAyah && audioType == 'chapter'"
-            type="checkbox"
-            :checked="stopPlayerOnAyahLock"
-            @change="toggleStopPlayerAyahOnLock"
-            id="stop-player-on-ayah-lock"
-            :disabled="segmentLocked"
-        />
-        <label
-            v-if="lockAyah && audioType == 'chapter'"
-            for="stop-player-on-ayah-lock"
-               class="mx-2 has-tooltip"
-               title="Checking this will stop player when ayah end time is reached.">
-          Stop player
         </label>
 
         <input
@@ -133,7 +120,8 @@
             :disabled="segmentLocked"
         />
         <label for="edit-mode"
-               class="mx-2 has-tooltip"
+               class="mx-2"
+               data-controller="tooltip"
                title="Edit mode will set the ayah timing when you click ayah start or end button. Clicking ayah end will also set start time of next ayah.">
           Edit Mode
         </label>
@@ -149,7 +137,8 @@
         <label
             v-if="editMode"
             for="auto-save"
-            class="mx-2 has-tooltip"
+            class="mx-2"
+            data-controller="tooltip"
             title="Auto save will automatically save ayah the segment timestamps.">
           Auto Save
         </label>
@@ -355,7 +344,6 @@ export default {
       "segmentLocked",
       "audioType",
       "lockAyah",
-      "stopPlayerOnAyahLock",
       "disableHotkeys",
       "showSegments",
       "autoScroll"
@@ -479,9 +467,6 @@ export default {
     },
     toggleLockAyah(event) {
       this.$store.commit("SET_AYAH_LOCK", {value: event.target.checked});
-    },
-    toggleStopPlayerAyahOnLock(event) {
-      this.$store.commit("SET_STOP_PLAYER_ON_AYAH_LOCK", {value: event.target.checked});
     }
   },
 };

--- a/app/javascript/segments/components/SelectAudioSrc.vue
+++ b/app/javascript/segments/components/SelectAudioSrc.vue
@@ -107,8 +107,8 @@ export default {
       this.$store.commit("SET_ALERT", {text: "Loading audio"});
     },
     audioReady() {
-      if(this.audioType == 'ayah' && this.autoPlay){
-      //  player.play();
+      if(this.audioType == 'ayah' && this.autoPlay && !this.lockAyah){
+        player.play();
       }
 
       this.$store.commit("SET_ALERT", {text: null});
@@ -149,7 +149,8 @@ export default {
       "playBackSpeed",
       "audioType",
       "playing",
-      "autoPlay"
+      "autoPlay",
+      "lockAyah"
     ]),
   },
 };

--- a/app/javascript/segments/components/Verse.vue
+++ b/app/javascript/segments/components/Verse.vue
@@ -107,7 +107,10 @@
                 </td>
 
                 <td :data-word="segment[0]" :data-index="index">
-                  <div class="d-flex gap-1">
+                  <div
+                      class="d-flex gap-1"
+                      :data-word="segment[0]" :data-index="index"
+                  >
                     <button
                       @click="insertSegment"
                       class="btn btn-sm btn-info"
@@ -333,6 +336,7 @@ export default {
       const target = event.target;
       const { word, index } = target.parentElement.dataset;
       const segStart = document.querySelector(`#start-${word}-${index}`);
+debugger
 
       if (segStart.value.length == 0) {
         this.$store.commit('TRACK_SEG_START', {

--- a/app/javascript/segments/store/index.js
+++ b/app/javascript/segments/store/index.js
@@ -46,8 +46,7 @@ const store = createStore({
       playbackSpeed: 1,
       autoSave: false,
       editMode: false,
-      lockAyah: false,
-      stopPlayerOnAyahLock: false,
+      lockAyah: false, // stop playing next ayah
       segmentLocked: false,
       audioType: 'chapter', //or ayah
       compareSegment: false,
@@ -134,7 +133,7 @@ const store = createStore({
     },
     SET_AYAH_ENDED(state) {
       if(state.lockAyah){
-        if(!player.paused && state.stopPlayerOnAyahLock) player.pause()
+        if(!player?.paused) player?.pause()
       } else {
         this.dispatch("LOAD_AYAH", {
           verse: state.currentVerseNumber + 1,
@@ -217,7 +216,7 @@ const store = createStore({
       }
 
       if(state.lockAyah){
-        if(!player.paused && state.stopPlayerOnAyahLock) player.pause()
+        if(!player?.paused) player?.pause()
       } else {
         this.dispatch("LOAD_AYAH", {
           verse: state.currentVerseNumber + 1,
@@ -232,9 +231,6 @@ const store = createStore({
     },
     SET_AYAH_LOCK(state, payload) {
       state.lockAyah = payload.value;
-    },
-    SET_STOP_PLAYER_ON_AYAH_LOCK(state, payload){
-      state.stopPlayerOnAyahLock = payload.value;
     },
     TRACK_SEG_START(state, payload) {
       const {
@@ -349,8 +345,8 @@ const store = createStore({
     SAVE_AYAH_SEGMENTS({
                          state
                        }) {
-      const isPlaying = !player.paused
-      if (isPlaying) player.pause()
+      const isPlaying = !player?.paused
+      if (isPlaying) player?.pause()
       state.alert = "Saving segments";
 
       const {
@@ -613,7 +609,7 @@ const store = createStore({
 
       if (verse && verse != currentVerseNumber) {
         if(state.lockAyah){
-          if(!player.paused && state.stopPlayerOnAyahLock) player.pause()
+          if(!player?.paused) player?.pause()
         } else{
           state.currentVerseNumber = verse;
           this.dispatch("LOAD_AYAH", {verse});


### PR DESCRIPTION
This PR will fix the "ayah locking" feature of segments tool.

While prepare segments of specific ayah, you'll want the player to stop and don't go to the next ayah. 

