### PR TITLE
[TA-1966] Fix sajdah marker of 38:24 for v1 layout

### DIFF
--- a/app/admin/draft/translation.rb
+++ b/app/admin/draft/translation.rb
@@ -48,6 +48,9 @@ ActiveAdmin.register Draft::Translation do
       link_to(resource.verse.verse_key, [:admin, resource.verse])
     end
     column :imported
+    column :resource do |resource|
+      link_to(resource.resource_content.name, [:admin, resource.resource_content])
+    end
     column :footnotes_count
     column :draft_text, sortable: :draft_text do |resource|
       resource.draft_text.to_s.first(50)
@@ -156,19 +159,25 @@ ActiveAdmin.register Draft::Translation do
   sidebar 'Draft translations', only: :index do
     translations = Draft::Translation.new_translations
     selected = params.dig(:q, :resource_content_id_eq).to_i
+
+    translations = translations.sort_by do |t|
+      t.id == selected ? 0 : 1
+    end
+
     imported = Draft::Translation.imported_translations.pluck(:id)
     div "Total: #{translations.size}"
     div "Imported: #{imported.size}"
 
     div class: 'd-flex w-100 flex-column sidebar-item' do
       translations.each do |resource_content|
-        div class: "w-100 p-1 flex-between border-bottom mb-3 #{'selected' if selected == resource_content.id}" do
-          div do
+        div class: "w-100 p-1 border-bottom mb-3 #{'selected' if selected == resource_content.id}" do
+          div class: 'flex-between' do
             span link_to(resource_content.id, [:admin, resource_content], target: 'blank')
             imported.include?(resource_content.id) ? span('imported', class: 'status_tag yes ms-2') : ''
           end
 
           div "#{resource_content.name}(#{resource_content.language_name})"
+          div "Synced: #{resource_content.meta_value('synced-at')} Updated: #{resource_content.updated_at}"
 
           div class: 'd-flex my-2 flex-between gap-2' do
             span(link_to 'Filter', "/admin/draft_translations?q%5Bresource_content_id_eq%5D=#{resource_content.id}", class: 'mb-2 btn btn-sm btn-info text-white')

--- a/lib/export_mushaf_layout.rb
+++ b/lib/export_mushaf_layout.rb
@@ -20,6 +20,20 @@ class ExportMushafLayout
     20, # Digital Khatt v2
     22, # Digital Khatt v1
   ]
+
+  CUSTOM_TEXT = {
+    # Sajdah marker is with the ayah marker for ayah: 38:24
+    # https://qul.tarteel.ai/admin/mushaf_page_preview?mushaf=2&compare=22&page=454&word=27496
+    code_v1: {
+      '38:24:32': 'ﯩ',
+      '38:24:33': 'ﯪﯫ',
+    },
+    text_digital_khatt_v1: {
+      '38:24:32': 'وَأَنَابَ',
+      '38:24:33': '۩۝٢٤'
+    }
+  }
+
   attr_accessor :mushafs,
                 :stats
 
@@ -51,14 +65,15 @@ class ExportMushafLayout
 
     Word.unscoped.order('word_index ASC').find_each do |word|
       surah, ayah, word_number = word.location.split(':').map(&:to_i)
-      text_uthmani = word.text_uthmani
-      text_indopak = word.text_qpc_nastaleeq_hafs
-      indopak_hanafi = word.text_indopak_nastaleeq
-      dk_indopak = word.text_digital_khatt_indopak
-      code_v1 = word.code_v1
-      text_digital_khatt_v2 = word.text_digital_khatt
-      text_digital_khatt_v1 = word.text_digital_khatt_v1
-      text_qpc_hafs = word.text_qpc_hafs
+      text_uthmani = get_word_text(word, 'text_uthmani')
+      text_indopak = get_word_text(word, 'text_qpc_nastaleeq_hafs')
+      indopak_hanafi = get_word_text(word, 'text_indopak_nastaleeq')
+      dk_indopak = get_word_text(word, 'text_digital_khatt_indopak')
+      code_v1 = get_word_text(word, 'code_v1')
+      text_digital_khatt_v2 = get_word_text(word, 'text_digital_khatt')
+      text_digital_khatt_v1 = get_word_text(word, 'text_digital_khatt_v1')
+      text_qpc_hafs = get_word_text(word, 'text_qpc_hafs')
+
       is_ayah_marker = word.ayah_mark?
 
       script_texts = [text_uthmani, text_indopak, indopak_hanafi, dk_indopak, code_v1, text_digital_khatt_v2, text_digital_khatt_v1, text_qpc_hafs]
@@ -262,6 +277,12 @@ class ExportMushafLayout
   ) VALUES
     #{values.join(',')}
     SQL
+  end
+
+  def get_word_text(word, script)
+    custom = CUSTOM_TEXT[script] || {}
+
+    custom[word.location.to_sym] || word.send(script)
   end
 
   def prepare_layout_stats(mushaf, table_name)

--- a/lib/importer/quran_enc.rb
+++ b/lib/importer/quran_enc.rb
@@ -135,6 +135,7 @@ module Importer
     end
 
     def after_import(resource)
+      resource.set_meta_value('synced-at', DateTime.now)
       if @issues.present?
         issues_group = @issues.group_by do |issue|
           issue[:tag]
@@ -190,6 +191,8 @@ module Importer
           end
         end
       end
+
+      resource.save
     end
 
     protected
@@ -488,7 +491,7 @@ module Importer
       lithuanian_rwwad: [/\[\d+\]/, /\[\d+\]/],
       telugu_muhammad: [/\([a-z]\)/, /\([a-z]\)/],
       chichewa_betala: [/\[\d+\]/, /\[\d+\]/],
-      punjabi_arif: [/\d+[਼\s]]?/, /\d+[਼\s]?]]/],
+      punjabi_arif: [/\d+[਼\s]*/, /\d+[਼\s]*/],
       lingala_zakaria: [/\(\d+\)/, /\d+/],
       kyrgyz_hakimov: [/\*+/, /\*+/],
       moore_rwwad: [/\[\d+\]/, /\[\d+\]/],


### PR DESCRIPTION
Sajdah marker is [part of ayah marker](https://tafsir.app/m-madinah-old/38/24) for v1 layout, waqf signs and sajdah markers are part of the previous words and was rendering on the wrong line. 

This PR introduced custom text mapping, we can fix the layout without updating the script using thus custom mapping.