### PR TITLE
feat: add API endpoints for available resources

### DIFF
--- a/app/controllers/api/resources_controller.rb
+++ b/app/controllers/api/resources_controller.rb
@@ -1,0 +1,135 @@
+module Api
+    class ResourcesController < ApplicationController
+      respond_to :json
+      
+      def index
+        @resources = {
+          recitations: format_recitations(get_recitations),
+          translations: format_translations(get_translations),
+          tafsirs: format_tafsirs(get_tafsirs),
+          scripts: get_scripts,
+          mushafs: format_mushafs(get_mushafs)
+        }
+        
+        render json: @resources
+      end
+      
+      def recitations
+        @recitations = format_recitations(get_recitations)
+        render json: @recitations
+      end
+      
+      def translations
+        @translations = format_translations(get_translations)
+        render json: @translations
+      end
+      
+      def tafsirs
+        @tafsirs = format_tafsirs(get_tafsirs)
+        render json: @tafsirs
+      end
+      
+      def scripts
+        @scripts = get_scripts
+        render json: @scripts
+      end
+      
+      def mushafs
+        @mushafs = format_mushafs(get_mushafs)
+        render json: @mushafs
+      end
+      
+      private
+      
+      def format_recitations(recitations)
+        recitations.map do |recitation|
+          {
+            id: recitation.id,
+            name: recitation.reciter_name,
+            description: recitation.style,
+            resource_type: 'recitation',
+            created_at: recitation.created_at,
+            updated_at: recitation.updated_at
+          }
+        end
+      end
+      
+      def format_translations(translations)
+        translations.map do |translation|
+          {
+            id: translation.id,
+            name: translation.resource_name,
+            language: translation.language_name,
+            resource_type: 'translation',
+            created_at: translation.created_at,
+            updated_at: translation.updated_at
+          }
+        end
+      end
+      
+      def format_tafsirs(tafsirs)
+        tafsirs.map do |tafsir|
+          {
+            id: tafsir.id,
+            name: tafsir.resource_name,
+            language: tafsir.language_name,
+            resource_type: 'tafsir',
+            created_at: tafsir.created_at,
+            updated_at: tafsir.updated_at
+          }
+        end
+      end
+      
+      def format_mushafs(mushafs)
+        mushafs.map do |mushaf|
+          {
+            id: mushaf.id,
+            name: mushaf.name,
+            description: mushaf.description,
+            pages_count: mushaf.pages_count,
+            lines_per_page: mushaf.lines_per_page,
+            enabled: mushaf.enabled,
+            is_default: mushaf.is_default,
+            default_font_name: mushaf.default_font_name,
+            qirat_type_id: mushaf.qirat_type_id
+          }
+        end
+      end
+      
+      def get_recitations
+        Recitation.approved
+      end
+      
+      def get_translations
+        resource_content_ids = Translation.distinct.pluck(:resource_content_id)
+        result = []
+        
+        resource_content_ids.each do |rc_id|
+          sampleTranslation = Translation.where(resource_content_id: rc_id).first
+          result << sampleTranslation if sampleTranslation
+        end
+        
+        result
+      end
+      
+      def get_tafsirs
+        resource_content_ids = Tafsir.distinct.pluck(:resource_content_id)
+        result = []
+        
+        resource_content_ids.each do |rc_id|
+          sampleTafsir = Tafsir.where(resource_content_id: rc_id).first
+          result << sampleTafsir if sampleTafsir
+        end
+        
+        result
+      end
+      
+      def get_scripts
+        []
+      end
+      
+      def get_mushafs
+        Mushaf.approved
+      end
+    end
+  end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,15 @@ Rails.application.routes.draw do
     get :mushaf
   end
 
+  namespace :api do
+    get 'resources', to: 'resources#index'
+    get 'resources/recitations', to: 'resources#recitations'
+    get 'resources/translations', to: 'resources#translations'
+    get 'resources/tafsirs', to: 'resources#tafsirs'
+    get 'resources/scripts', to: 'resources#scripts'
+    get 'resources/mushafs', to: 'resources#mushafs'
+  end
+
   get '/ayah/:key', to: 'ayah#show', as: :ayah
   match '/404', to: 'application#not_found', via: :all
   #  match '*unmatched', to: 'application#not_found', via: :all


### PR DESCRIPTION
Assalamualikum

## Overview
This PR adds API endpoints for available resources as mentioned in issue #242. 

## Implementation Details
- For recitations: Using `Recitation.approved` 
- For translations: Getting one sample translation per resource_content_id
- For tafsirs: Using a similar approach as translations
- For scripts: Returning an empty array*
- For mushafs: Using `Mushaf.approved`

*I was confused in figuring out a direct retrieval method for scripts as there are two seemingly related tables (`by_verse.rb`, `by_word.rb`)

For translations and tafsirs, I'm returning one sample per resource_content_id since I understand we want to list available resources, not individual translations of every verse. Please correct me if my understanding is wrong.

## Testing
I've manually tested all endpoints and they appear to be working, I didn't find any tests written previously so I haven't added tests for this PR - but I can add if required.

As someone new to Ruby on Rails, I did my best to follow good practices while creating these endpoints. I'm eager to learn and improve based on your feedback. Jazak Allah.