### PR TITLE
Add Mushaf with words color-coded according to part of speech

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -6,6 +6,7 @@
 @import "shared/tajweed";
 @import "shared/tajweed_color_new";
 @import "shared/mushaf_page";
+@import "shared/corpus";
 @import "shared/diffy";
 @import "shared/content";
 @import "admin/theme";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "shared/tajweed_color_new";
 @import "shared/content";
 @import "shared/diffy";
+@import "shared/corpus";
 @import "components/pdf_preview";
 @import "components/mutashabihat";
 @import "components/tajweed_rules";

--- a/app/assets/stylesheets/shared/corpus.scss
+++ b/app/assets/stylesheets/shared/corpus.scss
@@ -8,3 +8,147 @@
   font-size: 1.2em;
   font-weight: bold;
 }
+
+.navy, .emph {
+  color: #1301b8;
+}
+
+.navy-light, .conj{
+    color: #0000ff;
+}
+
+.seagreen, .v {
+  color: #32bd2f
+}
+
+.seagreen-light {
+  color: #3ece39;
+}
+
+.sky, .n {
+  color: #548dd4;
+}
+
+.sky-dark, .pron{
+    color: #3F70AA;
+}
+
+.sky-light {
+  color: #6f9fdb;
+}
+
+.metal {
+  color: #5c7085;
+}
+
+.metal-light {
+  color: #70869c;
+}
+
+.rust, .p {
+  color: #ad2323;
+}
+
+.rust-light {
+  color: #d73535;
+}
+
+.gray, .det {
+  color: #575757;
+}
+
+.orange, .impv {
+  color: #e37010;
+}
+
+.orange-dark, .fut{
+  color: #b65a0d;
+}
+
+.inl {
+    color: #e3a10f;
+}
+
+.t{
+    color: #89440a;
+}
+
+.orange-light {
+  color: #ef7d21;
+}
+
+.purple, .adj {
+  color: #8126c0;
+}
+
+.purple-light {
+  color: #9a3cd9;
+}
+
+.blue, .pn {
+  color: #257e9c;
+}
+
+.blue-light {
+  color: #2e9abe;
+}
+
+.brown, .dem {
+  color: #bf9f3e;
+}
+
+.brown-light {
+  color: #c9ad58;
+}
+
+.rose, .intg {
+  color: #fd5162;
+}
+
+.rose-light {
+  color: #fd6675
+}
+
+.gold, .rel {
+  color: #817418;
+}
+
+.prp{
+  color: #a8a800;
+}
+
+.gold-light {
+  color: #97881c
+}
+
+.red, .neg {
+  color: #f4400b;
+}
+
+.red-light {
+  color: #f76c44;
+}
+
+.green, .voc {
+  color: #1d6914
+}
+
+.green-light {
+  color: #278e1c;
+}
+
+.pink {
+  color: #a8017b;
+}
+
+.pink-light {
+  color: #d8019c;
+}
+
+.silver {
+  color: #b4b4b4;
+}
+
+.silver-light {
+  color: #bebebe;
+}

--- a/app/assets/stylesheets/shared/font_faces.scss
+++ b/app/assets/stylesheets/shared/font_faces.scss
@@ -137,6 +137,13 @@ $asset-version: "3.2";
 }
 
 @font-face {
+  font-family: "UthmanicHafs_V22";
+  src: local('KFGQPCHAFSUthmanicScript-Regula'),
+  url("#{$font-cdn}/UthmanicHafs_V22.woff2?v=#{$asset-version}") format('woff2'),
+  url("#{$font-cdn}/UthmanicHafs_V22.ttf?v=#{$asset-version}") format('truetype');
+}
+
+@font-face {
   font-family: KFGQPCHAFSColored-Bold;
   src: url("#{$font-cdn}/KFGQPCHAFSColored-Bold.ttf?v=#{$asset-version}")
 }

--- a/app/models/morphology/phrase_verse.rb
+++ b/app/models/morphology/phrase_verse.rb
@@ -56,11 +56,11 @@ class Morphology::PhraseVerse < ApplicationRecord
     if approved?
       s += 1
       s += (word_position_to - word_position_from) if 'new' == review_status
-      s += (phrase.approved? ? 7 : 0)
+      s += (phrase&.approved? ? 7 : 0)
     end
 
     s += ('new' == review_status ? 10 : 1)
-    s += (phrase.approved? ? 7 : 0)
+    s += (phrase&.approved? ? 7 : 0)
 
     s
   end

--- a/app/models/morphology/word_segment.rb
+++ b/app/models/morphology/word_segment.rb
@@ -3,19 +3,31 @@
 # Table name: morphology_word_segments
 #
 #  id                        :bigint           not null, primary key
+#  aspect_type               :string
+#  case_type                 :string
+#  derivation_type           :string
+#  gender_type               :string
 #  grammar_term_desc_arabic  :string
 #  grammar_term_desc_english :string
 #  grammar_term_key          :string
 #  grammar_term_name         :string
 #  hidden                    :boolean
 #  lemma_name                :string
+#  mood_type                 :string
+#  number_type               :string
 #  part_of_speech_key        :string
 #  part_of_speech_name       :string
+#  person_type               :string
 #  pos_tags                  :string
 #  position                  :integer
+#  pronoun_type              :string
 #  root_name                 :string
+#  segment_type              :string
+#  special_type              :string
+#  state_type                :string
 #  text_uthmani              :string
 #  verb_form                 :string
+#  voice_type                :string
 #  created_at                :datetime         not null
 #  updated_at                :datetime         not null
 #  grammar_concept_id        :bigint
@@ -29,16 +41,28 @@
 #
 # Indexes
 #
+#  index_morphology_word_segments_on_aspect_type          (aspect_type)
+#  index_morphology_word_segments_on_case_type            (case_type)
+#  index_morphology_word_segments_on_derivation_type      (derivation_type)
+#  index_morphology_word_segments_on_gender_type          (gender_type)
 #  index_morphology_word_segments_on_grammar_concept_id   (grammar_concept_id)
 #  index_morphology_word_segments_on_grammar_role_id      (grammar_role_id)
 #  index_morphology_word_segments_on_grammar_sub_role_id  (grammar_sub_role_id)
 #  index_morphology_word_segments_on_grammar_term_id      (grammar_term_id)
 #  index_morphology_word_segments_on_lemma_id             (lemma_id)
+#  index_morphology_word_segments_on_mood_type            (mood_type)
+#  index_morphology_word_segments_on_number_type          (number_type)
 #  index_morphology_word_segments_on_part_of_speech_key   (part_of_speech_key)
+#  index_morphology_word_segments_on_person_type          (person_type)
 #  index_morphology_word_segments_on_pos_tags             (pos_tags)
 #  index_morphology_word_segments_on_position             (position)
+#  index_morphology_word_segments_on_pronoun_type         (pronoun_type)
 #  index_morphology_word_segments_on_root_id              (root_id)
+#  index_morphology_word_segments_on_segment_type         (segment_type)
+#  index_morphology_word_segments_on_special_type         (special_type)
+#  index_morphology_word_segments_on_state_type           (state_type)
 #  index_morphology_word_segments_on_topic_id             (topic_id)
+#  index_morphology_word_segments_on_voice_type           (voice_type)
 #  index_morphology_word_segments_on_word_id              (word_id)
 #
 # Foreign Keys
@@ -50,6 +74,54 @@
 #
 
 class Morphology::WordSegment < QuranApiRecord
+  POS_TAG_COLORS = {
+    n: 'sky', # Noun
+    pn: 'blue', # Proper Noun
+    pron: 'sky', # Pronoun #TODO: Set Pronoun color based on pronoun type.
+    dem: 'brown', # Demonstrative
+    rel: 'gold', # Relative pronoun
+    adj: 'purple', # Adjective
+    v: 'seagreen', # Verb
+    p: 'rust', # Preposition
+    intg: 'rose', # Interrogative
+    voc: 'green', # Vocative
+    neg: 'red', # Negative
+    emph: 'navy', # Emphatic particle
+    prp: 'gold', # Purpose
+    impv: 'orange', # Imperative verb
+    fut: 'orange', # Future particle
+    conj: 'navy', # Conjunction
+    det: 'gray', # Determiner
+    inl: 'orange', # Initials (disconnected letters at the start of surahs)
+    t: 'orange', # Time adverb
+    loc: 'orange', # Location adverb
+    acc: 'orange', # Accusative case marker
+    cond: 'orange', # Conditional particle
+    sub: 'gold', # Subordinating conjunction
+    res: 'navy', # Restriction
+    exp: 'orange', # Exceptive particle
+    avr: 'orange', # Aversion particle
+    cert: 'orange', # Certainty particle
+    ret: 'orange', # Retraction particle
+    prev: 'orange', # Preventive particle
+    ans: 'navy', # Answer particle
+    inc: 'orange', # Inceptive particle
+    sur: 'orange', # Surprise particle
+    sup: 'navy', # Supplemental particle
+    exh: 'orange', # Exhortation particle
+    impn: 'orange', # Imperative verbal noun
+    exl: 'orange', # Explanation particle
+    eq: 'navy', # Equalization particle
+    rem: 'navy', # Resumption particle
+    caus: 'orange', # Cause particle
+    amd: 'navy', # Amendment particle
+    pro: 'red', # Prohibition particle
+    circ: 'navy', # Circumstantial (حال)
+    rslt: 'navy', # Result clause particle
+    int: 'orange', # Interpretation particle
+    com: 'navy' # Comitative particle (e.g., مع)
+  }.freeze
+
   belongs_to :word, class_name: 'Morphology::Word'
   belongs_to :grammar_concept, class_name: 'Morphology::GrammarConcept', optional: true
   belongs_to :grammar_role, class_name: 'Morphology::GrammarConcept', optional: true
@@ -59,7 +131,29 @@ class Morphology::WordSegment < QuranApiRecord
   belongs_to :root, optional: true
   belongs_to :topic, optional: true
   belongs_to :lemma, optional: true
+
   default_scope { order 'position asc' }
+
+  def pronoun_type
+    tag = self[:pronoun_type]
+    Corpus::Morphology::PronounType.new(tag: tag)
+  end
+
+  def get_segment_color
+    pos_tag = part_of_speech_key.to_s.downcase.to_sym
+
+=begin
+TODO: Set Pronoun color based on pronoun type.
+    if pos_tag == :pron
+      {
+        subj: 'sky',
+        obj: 'orange',
+      }[pronoun_type.tag.to_sym] || 'metal'
+    end
+=end
+
+    color = POS_TAG_COLORS[pos_tag]
+  end
 
   def is_prefix?
     has_pos_feature? 'PREF'

--- a/db/migrate/20250429092823_add_pos_tagging_to_word_segments.rb
+++ b/db/migrate/20250429092823_add_pos_tagging_to_word_segments.rb
@@ -1,0 +1,24 @@
+class AddPosTaggingToWordSegments < ActiveRecord::Migration[7.0]
+  def change
+    c = Morphology::WordSegment.connection
+    cols = [
+      :segment_type,
+      :person_type,
+      :voice_type,
+      :gender_type,
+      :number_type,
+      :aspect_type,
+      :mood_type,
+      :derivation_type,
+      :state_type,
+      :case_type,
+      :pronoun_type,
+      :special_type,
+      :text_qpc_hafs
+    ]
+    cols.each do |col|
+      c.add_column :morphology_word_segments, col, :string
+      c.add_index :morphology_word_segments, col
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_24_095514) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_29_092823) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/corpus/morphology/aspect_type.rb
+++ b/lib/corpus/morphology/aspect_type.rb
@@ -1,0 +1,32 @@
+module Corpus
+  module Morphology
+    class AspectType < OpenStruct
+      PERFECT    = new(tag: "PERF")
+      IMPERFECT  = new(tag: "IMPF")
+      IMPERATIVE = new(tag: "IMPV")
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when AspectType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def self.all
+        [PERFECT, IMPERFECT, IMPERATIVE]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/case_type.rb
+++ b/lib/corpus/morphology/case_type.rb
@@ -1,0 +1,32 @@
+module Corpus
+  module Morphology
+    class CaseType < OpenStruct
+      NOMINATIVE = new(tag: "NOM")
+      GENITIVE   = new(tag: "GEN")
+      ACCUSATIVE = new(tag: "ACC")
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when CaseType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def self.all
+        [NOMINATIVE, GENITIVE, ACCUSATIVE]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/derivation_type.rb
+++ b/lib/corpus/morphology/derivation_type.rb
@@ -1,0 +1,32 @@
+module Corpus
+  module Morphology
+    class DerivationType < OpenStruct
+      ACTIVE_PARTICIPLE  = new(tag: "ACT PCPL")
+      PASSIVE_PARTICIPLE = new(tag: "PASS PCPL")
+      VERBAL_NOUN        = new(tag: "VN")
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when DerivationType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def self.all
+        [ACTIVE_PARTICIPLE, PASSIVE_PARTICIPLE, VERBAL_NOUN]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/form_type.rb
+++ b/lib/corpus/morphology/form_type.rb
@@ -1,0 +1,45 @@
+module Corpus
+  module Morphology
+    class FormType < OpenStruct
+      FIRST   = new(tag: "I")
+      SECOND  = new(tag: "II")
+      THIRD   = new(tag: "III")
+      FOURTH  = new(tag: "IV")
+      FIFTH   = new(tag: "V")
+      SIXTH   = new(tag: "VI")
+      SEVENTH = new(tag: "VII")
+      EIGHTH  = new(tag: "VIII")
+      NINTH   = new(tag: "IX")
+      TENTH   = new(tag: "X")
+      ELEVENTH = new(tag: "XI")
+      TWELFTH = new(tag: "XII")
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when FormType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def self.all
+        [
+          FIRST, SECOND, THIRD, FOURTH, FIFTH,
+          SIXTH, SEVENTH, EIGHTH, NINTH, TENTH,
+          ELEVENTH, TWELFTH
+        ]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/gender_type.rb
+++ b/lib/corpus/morphology/gender_type.rb
@@ -1,0 +1,37 @@
+require 'ostruct'
+
+module Corpus
+  module Morphology
+    class GenderType < OpenStruct
+      MASCULINE = new(tag: "M")
+      FEMININE  = new(tag: "F")
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when GenderType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def hash
+        tag.hash
+      end
+
+      def self.all
+        [MASCULINE, FEMININE]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/mood_type.rb
+++ b/lib/corpus/morphology/mood_type.rb
@@ -1,0 +1,46 @@
+module Corpus
+  module Morphology
+    class MoodType < OpenStruct
+      INDICATIVE   = new(tag: "IND")
+      SUBJUNCTIVE  = new(tag: "SUBJ")
+      JUSSIVE      = new(tag: "JUS")
+
+      TAG_MAP = {
+        "IND"  => INDICATIVE,
+        "SUBJ" => SUBJUNCTIVE,
+        "JUS"  => JUSSIVE
+      }
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when MoodType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def hash
+        tag.hash
+      end
+
+      def self.parse(tag)
+        TAG_MAP[tag]
+      end
+
+      def self.all
+        [INDICATIVE, SUBJUNCTIVE, JUSSIVE]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/number_type.rb
+++ b/lib/corpus/morphology/number_type.rb
@@ -1,0 +1,36 @@
+module Corpus
+  module Morphology
+    class NumberType < OpenStruct
+      SINGULAR = new(tag: "S")
+      DUAL     = new(tag: "D")
+      PLURAL   = new(tag: "P")
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when NumberType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def hash
+        tag.hash
+      end
+
+      def self.all
+        [SINGULAR, DUAL, PLURAL]
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/part_of_speech.rb
+++ b/lib/corpus/morphology/part_of_speech.rb
@@ -1,0 +1,136 @@
+module Corpus
+  module Morphology
+    class PartOfSpeech < OpenStruct
+      NOUN                    = new(tag: "N")
+      PROPER_NOUN             = new(tag: "PN")
+      PRONOUN                 = new(tag: "PRON")
+      DEMONSTRATIVE           = new(tag: "DEM")
+      RELATIVE                = new(tag: "REL")
+      ADJECTIVE               = new(tag: "ADJ")
+      VERB                    = new(tag: "V")
+      PREPOSITION             = new(tag: "P")
+      INTERROGATIVE           = new(tag: "INTG")
+      VOCATIVE                = new(tag: "VOC")
+      NEGATIVE                = new(tag: "NEG")
+      EMPHATIC                = new(tag: "EMPH")
+      PURPOSE                 = new(tag: "PRP")
+      IMPERATIVE              = new(tag: "IMPV")
+      FUTURE                  = new(tag: "FUT")
+      CONJUNCTION             = new(tag: "CONJ")
+      DETERMINER              = new(tag: "DET")
+      INITIALS                = new(tag: "INL")
+      TIME                    = new(tag: "T")
+      LOCATION                = new(tag: "LOC")
+      ACCUSATIVE              = new(tag: "ACC")
+      CONDITIONAL             = new(tag: "COND")
+      SUBORDINATING_CONJUNCTION = new(tag: "SUB")
+      RESTRICTION             = new(tag: "RES")
+      EXCEPTIVE               = new(tag: "EXP")
+      AVERSION                = new(tag: "AVR")
+      CERTAINTY               = new(tag: "CERT")
+      RETRACTION              = new(tag: "RET")
+      PREVENTIVE              = new(tag: "PREV")
+      ANSWER                  = new(tag: "ANS")
+      INCEPTIVE               = new(tag: "INC")
+      SURPRISE                = new(tag: "SUR")
+      SUPPLEMENTAL            = new(tag: "SUP")
+      EXHORTATION             = new(tag: "EXH")
+      IMPERATIVE_VERBAL_NOUN  = new(tag: "IMPN")
+      EXPLANATION             = new(tag: "EXL")
+      EQUALIZATION            = new(tag: "EQ")
+      RESUMPTION              = new(tag: "REM")
+      CAUSE                   = new(tag: "CAUS")
+      AMENDMENT               = new(tag: "AMD")
+      PROHIBITION             = new(tag: "PRO")
+      CIRCUMSTANTIAL          = new(tag: "CIRC")
+      RESULT                  = new(tag: "RSLT")
+      INTERPRETATION          = new(tag: "INT")
+      COMITATIVE              = new(tag: "COM")
+
+      TAG_MAP = {
+        "N"   => NOUN,
+        "PN"  => PROPER_NOUN,
+        "PRON"=> PRONOUN,
+        "DEM" => DEMONSTRATIVE,
+        "REL" => RELATIVE,
+        "ADJ" => ADJECTIVE,
+        "V"   => VERB,
+        "P"   => PREPOSITION,
+        "INTG"=> INTERROGATIVE,
+        "VOC" => VOCATIVE,
+        "NEG" => NEGATIVE,
+        "EMPH"=> EMPHATIC,
+        "PRP" => PURPOSE,
+        "IMPV"=> IMPERATIVE,
+        "FUT" => FUTURE,
+        "CONJ"=> CONJUNCTION,
+        "DET" => DETERMINER,
+        "INL" => INITIALS,
+        "T"   => TIME,
+        "LOC" => LOCATION,
+        "ACC" => ACCUSATIVE,
+        "COND"=> CONDITIONAL,
+        "SUB" => SUBORDINATING_CONJUNCTION,
+        "RES" => RESTRICTION,
+        "EXP" => EXCEPTIVE,
+        "AVR" => AVERSION,
+        "CERT"=> CERTAINTY,
+        "RET" => RETRACTION,
+        "PREV"=> PREVENTIVE,
+        "ANS" => ANSWER,
+        "INC" => INCEPTIVE,
+        "SUR" => SURPRISE,
+        "SUP" => SUPPLEMENTAL,
+        "EXH" => EXHORTATION,
+        "IMPN"=> IMPERATIVE_VERBAL_NOUN,
+        "EXL" => EXPLANATION,
+        "EQ"  => EQUALIZATION,
+        "REM" => RESUMPTION,
+        "CAUS"=> CAUSE,
+        "AMD" => AMENDMENT,
+        "PRO" => PROHIBITION,
+        "CIRC"=> CIRCUMSTANTIAL,
+        "RSLT"=> RESULT,
+        "INT" => INTERPRETATION,
+        "COM" => COMITATIVE
+      }
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when PartOfSpeech
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      def hash
+        tag.hash
+      end
+
+      # Parse the tag to return the corresponding PartOfSpeech object
+      def self.parse(tag)
+        part_of_speech = TAG_MAP[tag]
+        if part_of_speech.nil?
+          raise UnsupportedOperationException, "Part of speech tag #{tag} not recognized."
+        end
+
+        part_of_speech
+      end
+
+      def self.all
+        TAG_MAP.values
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/part_of_speech_category.rb
+++ b/lib/corpus/morphology/part_of_speech_category.rb
@@ -1,0 +1,47 @@
+module Corpus
+  module Morphology
+    class PartOfSpeechCategory < OpenStruct
+      NOMINAL  = new(tag: "Nominal")
+      VERB     = new(tag: "Verb")
+      PARTICLE = new(tag: "Particle")
+
+      TAG_MAP = {
+        "Nominal"  => NOMINAL,
+        "Verb"     => VERB,
+        "Particle" => PARTICLE
+      }
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when PartOfSpeechCategory
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      # Parse the tag to return the corresponding PartOfSpeechCategory
+      def self.parse(tag)
+        category = TAG_MAP[tag]
+        if category.nil?
+          raise UnsupportedOperationException, "Part of speech category tag #{tag} not recognized."
+        end
+        category
+      end
+
+      def self.all
+        TAG_MAP.values
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/person_type.rb
+++ b/lib/corpus/morphology/person_type.rb
@@ -1,0 +1,48 @@
+module Corpus
+  module Morphology
+    class PersonType < OpenStruct
+      FIRST  = new(tag: "1")
+      SECOND = new(tag: "2")
+      THIRD  = new(tag: "3")
+
+      # Map for fast lookup by tag
+      TAG_MAP = {
+        "1" => FIRST,
+        "2" => SECOND,
+        "3" => THIRD
+      }
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when PersonType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      # Parse the tag to return the corresponding PersonType object
+      def self.parse(tag)
+        person_type = TAG_MAP[tag]
+        if person_type.nil?
+          raise UnsupportedOperationException, "PersonType tag #{tag} not recognized."
+        end
+        person_type
+      end
+
+      def self.all
+        TAG_MAP.values
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/pronoun_type.rb
+++ b/lib/corpus/morphology/pronoun_type.rb
@@ -1,0 +1,56 @@
+module Corpus
+  module Morphology
+    class PronounType < OpenStruct
+      OBJECT       = new(tag: "obj")
+      SECOND_OBJECT = new(tag: "obj2")
+      SUBJECT      = new(tag: "subj")
+
+      # Map for fast lookup by tag
+      TAG_MAP = {
+        "obj"  => OBJECT,
+        "obj2" => SECOND_OBJECT,
+        "subj" => SUBJECT
+      }
+
+      def to_s
+        tag
+      end
+
+      def cast(value)
+        TAG_MAP[value]
+      end
+
+      def serialize(value)
+        value.to_s
+      end
+
+      def ==(other)
+        case other
+        when PronounType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      # Parse the tag to return the corresponding PronounType object
+      def self.parse(tag)
+        pronoun_type = TAG_MAP[tag]
+        if pronoun_type.nil?
+          raise UnsupportedOperationException, "PronounType tag #{tag} not recognized."
+        end
+        pronoun_type
+      end
+
+      def self.all
+        TAG_MAP.values
+      end
+    end
+  end
+end

--- a/lib/corpus/morphology/segment_type.rb
+++ b/lib/corpus/morphology/segment_type.rb
@@ -1,0 +1,47 @@
+module Corpus
+  module Morphology
+    class SegmentType < OpenStruct
+      PREFIX = new(tag: "Prefix")
+      STEM   = new(tag: "Stem")
+      SUFFIX = new(tag: "Suffix")
+
+      TAG_MAP = {
+        "Prefix" => PREFIX,
+        "Stem"   => STEM,
+        "Suffix" => SUFFIX
+      }
+
+      def to_s
+        tag
+      end
+
+      def ==(other)
+        case other
+        when SegmentType
+          tag == other.tag
+        when String
+          tag == other
+        else
+          false
+        end
+      end
+
+      def eql?(other)
+        self == other
+      end
+
+      # Parse the tag to return the corresponding SegmentType object
+      def self.parse(tag)
+        segment_type = TAG_MAP[tag]
+        if segment_type.nil?
+          raise UnsupportedOperationException, "SegmentType tag #{tag} not recognized."
+        end
+        segment_type
+      end
+
+      def self.all
+        TAG_MAP.values
+      end
+    end
+  end
+end

--- a/lib/importer/tafsir_app.rb
+++ b/lib/importer/tafsir_app.rb
@@ -59,7 +59,7 @@ module Importer
       'ayah-morph' => 1518,
       'iraab-graphs' => 1550,
     }
-    
+
     def self.import_tafsirs(keys)
       keys.each do |key|
         importer = Importer::TafsirApp.new
@@ -79,9 +79,13 @@ module Importer
         next if verses_imported[verse.id].present?
 
         result = fetch_tafsir(key, verse)
-        tafsir = import_tafsir(verse, result, resource_content)
-        tafsir.ayah_group_ids.each do |id|
-          verses_imported[id] = true
+
+        if tafsir = import_tafsir(verse, result, resource_content)
+          tafsir.ayah_group_ids.each do |id|
+            verses_imported[id] = true
+          end
+        else
+          log_issue({tag: 'missing-tafsir', text: verse.verse_key })
         end
       end
 

--- a/lib/tasks/grammar.rake
+++ b/lib/tasks/grammar.rake
@@ -1,0 +1,66 @@
+namespace :grammar do
+  task generate_mushaf: :environment do
+    mushaf = Mushaf.where(name: 'Grammar colored').first_or_initialize
+    mushaf.lines_per_page = 15
+    mushaf.pages_count = 604
+    mushaf.default_font_name = 'qpc-hafs'
+    mushaf.qirat_type_id = 1
+    mushaf.save
+
+    qpc_hafs = Mushaf.find(5)
+
+    def uthmani_to_qpc_hafs(uthmani)
+      uthmani.gsub("ْ", "ۡ").gsub("۟", "ْ")
+    end
+
+    def build_word_text(mushaf_word)
+      puts mushaf_word.word_id
+      segments = Morphology::WordSegment.where(word_id: mushaf_word.word_id).order('position ASC')
+
+      texts = segments.map do |segment|
+        next if segment.text_uthmani.blank?
+        text = uthmani_to_qpc_hafs(segment.text_uthmani)
+
+        if segment.part_of_speech_key.present?
+          "<span class='#{segment.get_segment_color}'>#{text}</span>"
+        else
+          text
+        end
+      end
+
+      texts.compact_blank.join
+    end
+
+    MushafLineAlignment.where(mushaf_id: qpc_hafs.id).find_each do |line|
+      l = MushafLineAlignment.where(
+        mushaf_id: mushaf.id,
+        page_number: line.page_number,
+        line_number: line.line_number
+      ).first_or_initialize
+
+      l.attributes = line.attributes.except('id', 'mushaf_id', 'created_at', 'updated_at')
+      l.save(validate: false)
+    end
+
+    MushafPage.where(mushaf_id: qpc_hafs.id).find_each do |page|
+      p = MushafPage.where(
+        mushaf_id: mushaf.id,
+        page_number: page.page_number
+      ).first_or_initialize
+
+      p.attributes = page.attributes.except('id', 'mushaf_id', 'created_at', 'updated_at')
+      p.save(validate: false)
+    end
+
+    MushafWord.order('verse_id asc').where(mushaf_id: qpc_hafs.id).find_each do |word|
+      w = MushafWord.where(
+        mushaf_id: mushaf.id,
+        word_id: word.word_id
+      ).first_or_initialize
+
+      w.attributes = word.attributes.except('id', 'mushaf_id', 'created_at', 'updated_at')
+      w.text = build_word_text(word) if word.word?
+      w.save(validate: false)
+    end
+  end
+end


### PR DESCRIPTION
This PR:
- Add mushaf layout that'll render word segments, color coded according to their POS
- Added POS and related segment feature classes
  - These classes will be used later on while parsing morphology data 