### PR TITLE
Fix Scheema For Word Lemma & Stem 

### DIFF
--- a/db/migrate/20250509093155_add_lemma_id_and_stem_id_to_words.rb
+++ b/db/migrate/20250509093155_add_lemma_id_and_stem_id_to_words.rb
@@ -1,0 +1,10 @@
+class AddLemmaIdAndStemIdToWords < ActiveRecord::Migration[7.0]
+  def change
+    c = Word.connection
+    c.add_column :words, :lemma_id, :integer
+    c.add_index :words, :lemma_id
+
+    c.add_column :words, :stem_id, :integer
+    c.add_index :words, :stem_id
+  end
+end

--- a/lib/tasks/migrate_word_data.rake
+++ b/lib/tasks/migrate_word_data.rake
@@ -1,0 +1,50 @@
+namespace :db do
+  desc "Migrate WordLemmas and WordStems to words.lemma_id and words.stem_id"
+  task migrate_lemmas_and_stems: :environment do
+    # For Lemma
+    lemma_updated_count = 0
+    lemma_skipped = []
+
+    WordLemma.eager_load(:word).find_each do |word_lemma|
+      word = word_lemma.word
+      lemma = Lemma.find_by(id: word_lemma.lemma_id)
+
+      if word.nil? || word.lemma_id.present?
+        lemma_skipped << word_lemma.id
+        next
+      end
+
+      if lemma
+        word.update_column(:lemma_id, lemma.id)
+        lemma_updated_count += 1
+      end
+    end
+
+    puts "Lemma migration complete! #{lemma_updated_count} words updated with lemma_id."
+    puts "Skipped WordLemma IDs: #{lemma_skipped.join(', ')}" unless lemma_skipped.empty?
+
+    # For Lemma
+    stem_updated_count = 0
+    stem_skipped = []
+
+    WordStem.eager_load(:word).find_each do |word_stem|
+      word = word_stem.word
+      stem = Stem.find_by(id: word_stem.stem_id)
+
+      if word.nil? || word.stem_id.present?
+        stem_skipped << word_stem.id
+        next
+      end
+
+      if stem
+        word.update_column(:stem_id, stem.id)
+        stem_updated_count += 1
+      end
+    end
+
+    puts "Stem migration complete! #{stem_updated_count} words updated with stem_id."
+    puts "Skipped WordStem IDs: #{stem_skipped.join(', ')}" unless stem_skipped.empty?
+
+    puts "All migrations completed."
+  end
+end


### PR DESCRIPTION

This PR update the Word -> `Lemma&Stem` schema. Migrate from `many to many` to `one to many` relation.
Added `lemma_id` and `stem_id `columns to the `words table`.