### PR TITLE
Import Warsh Data 

### DIFF
--- a/app/models/quran_script/by_verse.rb
+++ b/app/models/quran_script/by_verse.rb
@@ -5,22 +5,27 @@
 #  id                  :bigint           not null, primary key
 #  key                 :string
 #  text                :string
+#  verse_number        :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  chapter_id          :integer
 #  qirat_id            :integer
 #  resource_content_id :integer
 #  verse_id            :integer
 #
 # Indexes
 #
+#  index_quran_script_by_verses_on_chapter_id           (chapter_id)
 #  index_quran_script_by_verses_on_key                  (key)
 #  index_quran_script_by_verses_on_qirat_id             (qirat_id)
 #  index_quran_script_by_verses_on_resource_content_id  (resource_content_id)
 #  index_quran_script_by_verses_on_text                 (text)
 #  index_quran_script_by_verses_on_verse_id             (verse_id)
+#  index_quran_script_by_verses_on_verse_number         (verse_number)
 #
 class QuranScript::ByVerse < QuranApiRecord
   belongs_to :resource_content
+  belongs_to :chapter
   belongs_to :verse
   belongs_to :qirat, class_name: 'QiratType'
 end

--- a/app/models/quran_script/by_word.rb
+++ b/app/models/quran_script/by_word.rb
@@ -5,8 +5,11 @@
 #  id                  :bigint           not null, primary key
 #  key                 :string
 #  text                :string
+#  verse_number        :integer
+#  word_number         :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  chapter_id          :integer
 #  qirat_id            :string
 #  resource_content_id :string
 #  verse_id            :string
@@ -14,16 +17,20 @@
 #
 # Indexes
 #
+#  index_quran_script_by_words_on_chapter_id           (chapter_id)
 #  index_quran_script_by_words_on_key                  (key)
 #  index_quran_script_by_words_on_qirat_id             (qirat_id)
 #  index_quran_script_by_words_on_resource_content_id  (resource_content_id)
 #  index_quran_script_by_words_on_text                 (text)
 #  index_quran_script_by_words_on_verse_id             (verse_id)
+#  index_quran_script_by_words_on_verse_number         (verse_number)
 #  index_quran_script_by_words_on_word_id              (word_id)
+#  index_quran_script_by_words_on_word_number          (word_number)
 #
 class QuranScript::ByWord < QuranApiRecord
   belongs_to :resource_content
   belongs_to :word
   belongs_to :verse
+  belongs_to :chapter
   belongs_to :qirat, class_name: 'QiratType'
 end

--- a/db/migrate/20250711104903_add_columns_to_quran_script_tables.rb
+++ b/db/migrate/20250711104903_add_columns_to_quran_script_tables.rb
@@ -1,0 +1,15 @@
+class AddColumnsToQuranScriptTables < ActiveRecord::Migration[7.0]
+  def change
+    c = Verse.connection
+    c.change_table :quran_script_by_verses do |t|
+      t.integer :chapter_id, index: true
+      t.integer :verse_number, index: true
+    end
+
+    c.change_table :quran_script_by_words do |t|
+      t.integer :chapter_id, index: true
+      t.integer :verse_number, index: true
+      t.integer :word_number, index: true
+    end
+  end
+end

--- a/lib/tasks/import_warsh.rake
+++ b/lib/tasks/import_warsh.rake
@@ -1,0 +1,116 @@
+namespace :quran_script do
+############### import_warsh_by_verse #################
+  desc "Import Uthmanic Warsh V21 into quran_script_by_verses"
+  task import_warsh: :environment do
+    rc = ResourceContent.find_or_create_by!(
+      slug:     "quran-script-warsh-v21",
+      language: Language.find_by!(iso_code: "ar")
+    ) do |r|
+      r.name             = "Quran Script (Uthmanic Warsh V21)"
+      r.sub_type         = ResourceContent::SubType::QuranText
+      r.cardinality_type = ResourceContent::CardinalityType::OneVerse
+    end
+    warsh = QiratType.find_or_create_by!(name: "Warsh")
+
+    QuranScript::ByVerse.where(
+      resource_content_id: rc.id,
+      qirat_id:            warsh.id
+    ).delete_all
+
+    path  = Rails.root.join("data", "quran complex", "UthmanicWarsh V21.docx.txt")
+    whole = File.read(path, encoding: "utf-8")
+    total = 0
+
+    whole.split(/^سُورَةُ/).reject(&:blank?).each_with_index do |chunk, i|
+      chapter_id = i + 1
+      lines      = chunk.lines.map(&:strip).reject { |l|
+        l.blank? || l.include?("بِسْمِ") || l =~ /^_{2,}$/
+      }
+      lines.shift
+      text = lines.join(" ")
+
+      text.scan(/(.+?)[\s ]+([\u0660-\u0669]+)/) do |frag, num|
+        verse_num = num.chars.map { |c| c.ord - 0x0660 }.join.to_i
+        verse     = Verse.find_by(chapter_id: chapter_id, verse_number: verse_num)
+        next unless verse
+
+        QuranScript::ByVerse.create!(
+          resource_content_id: rc.id,
+          qirat_id:            warsh.id,
+          chapter_id:          chapter_id,
+          verse_id:            verse.id,
+          verse_number:        verse_num,
+          text:                frag.strip,
+          key:                 "#{chapter_id}:#{verse_num}"
+        )
+        total += 1
+      end
+
+      expected = Verse.where(chapter_id: chapter_id).pluck(:verse_number)
+      imported = QuranScript::ByVerse.where(
+        resource_content_id: rc.id,
+        qirat_id:            warsh.id,
+        chapter_id:          chapter_id
+      ).pluck(:verse_number)
+      (expected - imported).each do |v|
+        Rails.logger.warn "skipped verse #{chapter_id}:#{v}"
+      end
+    end
+
+    puts "Imported verses: #{total}"
+  end
+
+######################### import_warsh_by_words #################################
+  desc "Import Uthmanic Warsh V21 into quran_script_by_words"
+  task import_warsh_by_words: :environment do
+    rc    = ResourceContent.find_by!(slug: "quran-script-warsh-v21")
+    warsh = QiratType.find_by!(name: "Warsh")
+
+    QuranScript::ByWord.where(
+      resource_content_id: rc.id,
+      qirat_id:            warsh.id
+    ).delete_all
+
+    path       = Rails.root.join("data", "quran complex", "UthmanicWarsh V21.docx.txt")
+    whole      = File.read(path, encoding: "utf-8")
+    total_words = 0
+
+    whole.split(/^سُورَةُ/).reject(&:blank?).each_with_index do |chunk, i|
+      chapter_id = i + 1
+      lines      = chunk.lines.map(&:strip).reject { |l|
+        l.blank? || l.include?("بِسْمِ") || l =~ /^_{2,}$/
+      }
+      lines.shift
+      text = lines.join(" ")
+
+      text.scan(/(.+?)[\s ]+([\u0660-\u0669]+)/) do |verse_text, num|
+        verse_num = num.chars.map { |c| c.ord - 0x0660 }.join.to_i
+        verse     = Verse.find_by(chapter_id: chapter_id, verse_number: verse_num)
+        next unless verse
+
+        tokens     = verse_text.strip.split(/[[:space:]\u00A0]+/)
+        words_db   = Word.where(verse_id: verse.id).order(:position).to_a
+
+        tokens.each_with_index do |tok, idx|
+          w = words_db[idx]
+          next unless w
+
+          QuranScript::ByWord.create!(
+            resource_content_id: rc.id,
+            qirat_id:            warsh.id,
+            chapter_id:          chapter_id,
+            verse_id:            verse.id,
+            verse_number:        verse_num,
+            word_id:             w.id,
+            word_number:         idx + 1,
+            text:                tok.strip,
+            key:                 "#{chapter_id}:#{verse_num}:#{idx + 1}"
+          )
+          total_words += 1
+        end
+      end
+    end
+
+    puts "Imported words: #{total_words}"
+  end
+end


### PR DESCRIPTION
This pull request adds a Rake task to `import Quranic Warsh script data`, both `verse by verse` and `word by word`.

To run the import tasks, use the following commands:

```
rails quran_script:import_warsh
rails quran_script:import_warsh_by_words

```

