### PR TITLE
UloomQuran Resource

### DIFF
--- a/app/admin/content/chapter_uloom_quran.rb
+++ b/app/admin/content/chapter_uloom_quran.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register UloomQuran::ByChapter do
+  menu parent: 'Content'
+  actions :all, except: :destroy
+
+  includes :chapter, :resource_content
+
+  filter :resource_content,
+         as: :searchable_select,
+         ajax: { resource: ResourceContent }
+  filter :language,
+         as: :searchable_select,
+         ajax: { resource: Language }
+  filter :chapter,
+         as: :searchable_select,
+         ajax: { resource: Chapter }
+
+
+  filter :text
+end

--- a/app/admin/content/resource_content.rb
+++ b/app/admin/content/resource_content.rb
@@ -407,9 +407,18 @@ ActiveAdmin.register ResourceContent do
         end
       elsif resource.mushaf_layout?
         link_to 'Mushaf pages', "/cms/mushaf_pages?q%5Bmushaf_id_eq%5D=#{resource.get_mushaf_id}"
+      elsif resource.uloom_quran?
+        safe_join([
+                    link_to('UloomQuran – By Verse',   "/cms/uloom_quran_by_verses?q%5Bresource_content_id_eq%5D=#{resource.id}"),
+                    tag(:br),
+                    link_to('UloomQuran – By Word',    "/cms/uloom_quran_by_words?q%5Bresource_content_id_eq%5D=#{resource.id}"),
+                    tag(:br),
+                    link_to('UloomQuran – By Chapter', "/cms/uloom_quran_by_chapters?q%5Bresource_content_id_eq%5D=#{resource.id}")
+                  ])
       end
     end
   end
+
 
   sidebar 'Export data', only: :show, if: -> { can?(:export, resource) && (resource.translation? || resource.tafsir?) } do
     div do

--- a/app/admin/content/verse_uloom_quran.rb
+++ b/app/admin/content/verse_uloom_quran.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register UloomQuran::ByVerse do
+  menu parent: 'Content'
+  actions :all, except: :destroy
+
+  includes :chapter, :verse, :resource_content
+
+  filter :resource_content,
+         as: :searchable_select,
+         ajax: { resource: ResourceContent }
+  filter :language,
+         as: :searchable_select,
+         ajax: { resource: Language }
+  filter :chapter,
+         as: :searchable_select,
+         ajax: { resource: Chapter }
+  filter :verse,
+         as: :searchable_select,
+         ajax: { resource: Verse }
+  filter :from,
+         as: :numeric,
+         label: 'Verse From'
+  filter :to,
+         as: :numeric,
+         label: 'Verse To'
+
+  filter :text
+end

--- a/app/admin/content/word_uloom_quran.rb
+++ b/app/admin/content/word_uloom_quran.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register UloomQuran::ByWord do
+  menu parent: 'Content'
+  actions :all, except: :destroy
+
+  includes :chapter, :verse, :word, :resource_content
+
+  filter :resource_content,
+         as: :searchable_select,
+         ajax: { resource: ResourceContent }
+  filter :language,
+         as: :searchable_select,
+         ajax: { resource: Language }
+  filter :chapter,
+         as: :searchable_select,
+         ajax: { resource: Chapter }
+  filter :verse,
+         as: :searchable_select,
+         ajax: { resource: Verse }
+  filter :word,
+         as: :searchable_select,
+         ajax: { resource: Word }
+  filter :from,
+         as: :numeric,
+         label: 'Word From'
+  filter :to,
+         as: :numeric,
+         label: 'Word To'
+
+  filter :text
+end

--- a/app/models/resource_content.rb
+++ b/app/models/resource_content.rb
@@ -6,6 +6,7 @@
 #  id                     :integer          not null, primary key
 #  approved               :boolean
 #  author_name            :string
+#  book_name              :string
 #  cardinality_type       :string
 #  description            :text
 #  language_name          :string
@@ -71,6 +72,7 @@ class ResourceContent < QuranApiRecord
   scope :with_footnotes, -> { where("meta_data ->> 'has-footnote' = 'yes'") }
   scope :with_segments, -> { where("meta_data ->> 'has-segments' = 'yes'") }
   scope :fonts, -> { where sub_type: SubType::Font }
+  scope :uloom_quran, -> { where sub_type: SubType::UloomQuran }
   scope :approved, -> { where approved: true }
   scope :for_language, lambda { |lang| where(language: Language.find_by_iso_code(lang)) }
   scope :permission_to_host_eq, lambda { |val|
@@ -191,6 +193,7 @@ class ResourceContent < QuranApiRecord
     MetaData = 'meta'
     Morphology = 'morphology'
     Font = 'font'
+    UloomQuran = 'uloom-quran'
   end
 
   def get_language_name
@@ -222,6 +225,10 @@ class ResourceContent < QuranApiRecord
 
   def quran_script?
     sub_type == SubType::QuranText
+  end
+
+  def uloom_quran?
+    sub_type == SubType::UloomQuran
   end
 
   def font?

--- a/app/models/uloom_quran.rb
+++ b/app/models/uloom_quran.rb
@@ -1,0 +1,5 @@
+module UloomQuran
+  def self.table_name_prefix
+    'uloom_quran_'
+  end
+end

--- a/app/models/uloom_quran/by_chapter.rb
+++ b/app/models/uloom_quran/by_chapter.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: uloom_quran_by_chapters
+#
+#  id                  :bigint           not null, primary key
+#  language_name       :string
+#  meta_data           :jsonb            not null
+#  text                :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  chapter_id          :integer
+#  language_id         :integer
+#  resource_content_id :integer
+#
+# Indexes
+#
+#  index_uloom_quran_by_chapters_on_chapter_id           (chapter_id)
+#  index_uloom_quran_by_chapters_on_language_id          (language_id)
+#  index_uloom_quran_by_chapters_on_language_name        (language_name)
+#  index_uloom_quran_by_chapters_on_resource_content_id  (resource_content_id)
+#  index_uloom_quran_by_chapters_on_text                 (text)
+#
+class UloomQuran::ByChapter < QuranApiRecord
+  belongs_to :resource_content
+  belongs_to :chapter
+  belongs_to :language
+end

--- a/app/models/uloom_quran/by_verse.rb
+++ b/app/models/uloom_quran/by_verse.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: uloom_quran_by_verses
+#
+#  id                  :bigint           not null, primary key
+#  from                :integer
+#  language_name       :string
+#  meta_data           :jsonb            not null
+#  text                :text
+#  to                  :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  chapter_id          :integer
+#  language_id         :integer
+#  resource_content_id :integer
+#  verse_id            :integer
+#
+# Indexes
+#
+#  index_uloom_quran_by_verses_on_chapter_id           (chapter_id)
+#  index_uloom_quran_by_verses_on_from                 (from)
+#  index_uloom_quran_by_verses_on_language_id          (language_id)
+#  index_uloom_quran_by_verses_on_language_name        (language_name)
+#  index_uloom_quran_by_verses_on_resource_content_id  (resource_content_id)
+#  index_uloom_quran_by_verses_on_text                 (text)
+#  index_uloom_quran_by_verses_on_to                   (to)
+#  index_uloom_quran_by_verses_on_verse_id             (verse_id)
+#
+class UloomQuran::ByVerse < QuranApiRecord
+  belongs_to :resource_content
+  belongs_to :chapter
+  belongs_to :verse
+  belongs_to :language
+end

--- a/app/models/uloom_quran/by_word.rb
+++ b/app/models/uloom_quran/by_word.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: uloom_quran_by_words
+#
+#  id                  :bigint           not null, primary key
+#  from                :integer
+#  language_name       :string
+#  meta_data           :jsonb            not null
+#  text                :text
+#  to                  :integer
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  chapter_id          :integer
+#  language_id         :integer
+#  resource_content_id :integer
+#  verse_id            :integer
+#  word_id             :integer
+#
+# Indexes
+#
+#  index_uloom_quran_by_words_on_chapter_id           (chapter_id)
+#  index_uloom_quran_by_words_on_from                 (from)
+#  index_uloom_quran_by_words_on_language_id          (language_id)
+#  index_uloom_quran_by_words_on_language_name        (language_name)
+#  index_uloom_quran_by_words_on_resource_content_id  (resource_content_id)
+#  index_uloom_quran_by_words_on_text                 (text)
+#  index_uloom_quran_by_words_on_to                   (to)
+#  index_uloom_quran_by_words_on_verse_id             (verse_id)
+#  index_uloom_quran_by_words_on_word_id              (word_id)
+#
+class UloomQuran::ByWord < QuranApiRecord
+  belongs_to :resource_content
+  belongs_to :chapter
+  belongs_to :verse
+  belongs_to :word
+  belongs_to :language
+
+end
+

--- a/db/migrate/20250710120919_create_uloom_quran_by_words.rb
+++ b/db/migrate/20250710120919_create_uloom_quran_by_words.rb
@@ -1,0 +1,21 @@
+class CreateUloomQuranByWords < ActiveRecord::Migration[7.0]
+  def change
+    c = Verse.connection
+    c.create_table :uloom_quran_by_words do |t|
+      t.text    :text,                index: true
+      t.string  :cardinality_type,    index: true
+      t.integer :language_id,         index: true
+      t.string  :language_name,       index: true
+      t.integer :resource_content_id, index: true
+      t.integer :chapter_id,          index: true
+      t.integer :verse_id,            index: true
+      t.integer :word_id,             index: true
+      t.integer :from,                index: true
+      t.integer :to,                  index: true
+
+      t.jsonb   :meta_data,           default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250710120931_create_uloom_quran_by_verses.rb
+++ b/db/migrate/20250710120931_create_uloom_quran_by_verses.rb
@@ -1,0 +1,20 @@
+class CreateUloomQuranByVerses < ActiveRecord::Migration[7.0]
+  def change
+    c = Verse.connection
+    c.create_table :uloom_quran_by_verses do |t|
+      t.text    :text,                index: true
+      t.string  :cardinality_type,    index: true
+      t.integer :language_id,         index: true
+      t.string  :language_name,       index: true
+      t.integer :resource_content_id, index: true
+      t.integer :chapter_id,          index: true
+      t.integer :verse_id,            index: true
+      t.integer :from,                index: true
+      t.integer :to,                  index: true
+
+      t.jsonb   :meta_data,           default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250712210812_create_uloom_quran_by_chapters.rb
+++ b/db/migrate/20250712210812_create_uloom_quran_by_chapters.rb
@@ -1,0 +1,17 @@
+class CreateUloomQuranByChapters < ActiveRecord::Migration[7.0]
+  def change
+    c = Verse.connection
+    c.create_table :uloom_quran_by_chapters do |t|
+      t.text    :text,                index: true
+      t.string  :cardinality_type,    index: true
+      t.integer :language_id,         index: true
+      t.string  :language_name,       index: true
+      t.integer :resource_content_id, index: true
+      t.integer :chapter_id,          index: true
+
+      t.jsonb   :meta_data,           default: {}, null: false
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
Add a new `UloomQuran` `subtype` to `ResourceContent` for storing `Quran grammar data`.

Add a new resource called `UloomQuran` to store `Quranic grammar data`, including separate tables for `verse-level`, `word-level`, and `chapter-level` entries