### PR TITLE
Fix UI issues on Resources and Tools pages

### DIFF
--- a/app/assets/stylesheets/landing_page/_tool_cards.scss
+++ b/app/assets/stylesheets/landing_page/_tool_cards.scss
@@ -23,6 +23,7 @@ a.tool-card-with-bg {
 }
 
 .tool-card-with-bg{
+  height: 500px;
   background-repeat: no-repeat !important;
   background-size: cover;
   background-position: center;

--- a/app/views/arabic_transliterations/index.html.erb
+++ b/app/views/arabic_transliterations/index.html.erb
@@ -25,10 +25,10 @@
 
 <div class="page-wrapper container-lg">
   <div class="page-section">
-    <h2>Ayah list</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Ayah list</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 tw-bg-white">
       <tr>
         <th><%= sort_order_link 'Ayah key', :verse_key %></th>
         <th>Progress</th>
@@ -77,5 +77,3 @@
     </div>
   </div>
 </div>
-
-

--- a/app/views/arabic_transliterations/show.html.erb
+++ b/app/views/arabic_transliterations/show.html.erb
@@ -81,7 +81,7 @@
   <div class="page-section tw-mt-4">
     <h2>Words</h2>
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <td>Word id</td>
         <td>IndoPak</td>

--- a/app/views/ayah_audio_files/index.html.erb
+++ b/app/views/ayah_audio_files/index.html.erb
@@ -29,10 +29,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Ayah segments</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Ayah segments</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Id', :id, id: @recitation.id %></th>
         <th><%= sort_order_link 'Surah', :chapter_id %></th>

--- a/app/views/ayah_audio_files/show.html.erb
+++ b/app/views/ayah_audio_files/show.html.erb
@@ -23,7 +23,7 @@
   <div class="page-section">
     <h3>Segments</h3>
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Verse', :verse_number, id: @recitation.id %></th>
         <th>Duration</th>

--- a/app/views/card/_card-container.erb
+++ b/app/views/card/_card-container.erb
@@ -8,7 +8,7 @@
 %>
 
 <%= content_tag tag_name, class: "tw-w-full tw-inline-block", **href_attr, data: data_attrs  do %>
-  <div class="tw-relative tw-rounded-[45px] tw-h-[auto] md:tw-h-[550px] tool-card-with-bg tw-px-8 tw-py-6 tw-relative <%= "#{card_type} pattern#{pattern}" %>">
+  <div class="tw-relative tw-rounded-[45px] tw-h-[550px] tool-card-with-bg tw-px-8 tw-py-6 tw-relative <%= "#{card_type} pattern#{pattern}" %>">
     <div class="overlay"></div>
     <%= yield %>
   </div>

--- a/app/views/community/_char_info_form.html.erb
+++ b/app/views/community/_char_info_form.html.erb
@@ -89,7 +89,7 @@
 
       <div class="tw-overflow-x-auto">   
       <table class="table table-hover">
-        <thead class="position-sticky bg-white border-bottom top-0">
+        <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
         <tr class="sticky">
           <th>#</th>
           <th style="width: 100px">Name</th>

--- a/app/views/community/_chars_table.html.erb
+++ b/app/views/community/_chars_table.html.erb
@@ -18,7 +18,7 @@
 
     <div>
       <table class="table table-hover text-center">
-        <thead class="position-sticky bg-white border-bottom top-0">
+        <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
         <tr>
           <th>Location</th>
           <th>Text</th>

--- a/app/views/morphology_phrases/_phrase_list.html.erb
+++ b/app/views/morphology_phrases/_phrase_list.html.erb
@@ -17,10 +17,10 @@
 </div>
 
 <div class="page-section mt-4">
-  <h2>Phrase list</h2>
+  <h2 class="tw-text-2xl tw-mb-4">Phrase list</h2>
   <div class="tw-overflow-x-auto">
   <table class="table table-hover mt-4">
-    <thead class="position-sticky bg-white border-bottom top-0">
+    <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
     <tr>
       <th><%= sort_order_link 'Id', :id %></th>
       <th><%= sort_order_link 'Ayah', :source_verse_id %></th>

--- a/app/views/morphology_phrases/_proofread_list.html.erb
+++ b/app/views/morphology_phrases/_proofread_list.html.erb
@@ -15,7 +15,7 @@
 <div class="page-section mt-4">
   <h2>Ayah phrases list</h2>
   <table class="table table-hover mt-4">
-    <thead class="position-sticky bg-white border-bottom top-0">
+    <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
     <tr>
       <th><%= sort_order_link 'Ayah Key', :verse_index, proofread: true %></th>
       <th>Phrases</th>

--- a/app/views/mushaf_layouts/_page_mapping.html.erb
+++ b/app/views/mushaf_layouts/_page_mapping.html.erb
@@ -16,7 +16,7 @@
 
   <section class="highlight mt-4">
     <table class="table table-hover mt-4">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Page', :page_number, view_type: 'page_mapping', mushaf_id: @resource.id, page_number: params[:page_number] %></th>
         <th>Ayah Range</th>

--- a/app/views/mushaf_layouts/index.html.erb
+++ b/app/views/mushaf_layouts/index.html.erb
@@ -6,10 +6,10 @@
 
 <div class="page-wrapper container-lg">
   <div class="page-section">
-    <h2>Mushaf list</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Mushaf list</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th>
           <%= sort_order_link 'Id', :id %>

--- a/app/views/resources/previews/_font.html.erb
+++ b/app/views/resources/previews/_font.html.erb
@@ -166,7 +166,7 @@
             <h2>Ligatures</h2>
             <div class="tw-overflow-x-auto">
               <table class="table table-hover">
-                <thead class="position-sticky bg-white border-bottom top-0">
+                <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
                 <tr>
                   <th>
                     #

--- a/app/views/resources/resources_view/_list.html.erb
+++ b/app/views/resources/resources_view/_list.html.erb
@@ -1,12 +1,12 @@
 <div class="resources-table">
   <table class="tw-w-full tw-mt-8">
-    <thead class="tw-min-w-full">
+    <thead class="tw-sticky tw-top-0 tw-z-10 tw-min-w-full">
       <tr class="tw-border-b tw-bg-slate-100 tw-text-sm">
-        <th class="tw-py-3 tw-px-4 tw-font-normal tw-flex">
+        <th class="tw-py-3 tw-px-4 tw-font-normal tw-whitespace-nowrap">
           <%= sort_order_link 'Resource', :name, {}, data: { turbo_action: 'advance' } %>
         </th>
         <th class="tw-py-3 tw-px-4 tw-font-normal tw-hidden sm:tw-table-cell">Description</th>
-        <th class="tw-py-3 tw-px-4 tw-font-normal tw-flex">
+        <th class="tw-py-3 tw-px-4 tw-font-normal tw-whitespace-nowrap">
           <%= sort_order_link 'Count', :count %>
         </th>
       </tr>
@@ -22,14 +22,14 @@
                 <div>
                   <%= inline_svg_tag "svgs/#{card.list_icon || 'layout.svg'}" %>
                 </div>
-                <div class="tw-space-y-1.5">
+                <div class="tw-space-y-3">
                   <span class="tw-block tw-font-semibold">
                     <%= card.title %>
                   </span>
                   <span class="tw-block tw-text-gray-500 tw-text-xs">
                     <%= card.stats.to_s.html_safe if card.respond_to?(:stats) %>
                   </span>
-                  <span class="tw-block tw-text-gray-500 tw-text-xs tw-mt-1 sm:tw-hidden">
+                  <span class="tw-block tw-text-gray-500 tw-text-xs tw-mt-1 sm:tw-hidden tw-w-full">
                     <%= card.description %>
                   </span>
                 </div>

--- a/app/views/segments/dashboard/_logs.html.erb
+++ b/app/views/segments/dashboard/_logs.html.erb
@@ -4,7 +4,7 @@
 
     <div class="tw-overflow-x-auto">
       <table class="table table-hover">
-        <thead class="position-sticky bg-white border-bottom top-0">
+        <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
         <tr class="tw-bg-gray-100 tw-text-left">
           <th class="tw-p-2 tw-border-b">Time</th>
           <th class="tw-p-2 tw-border-b">Surah</th>

--- a/app/views/surah_audio_files/index.html.erb
+++ b/app/views/surah_audio_files/index.html.erb
@@ -35,10 +35,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Surah list</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Surah list</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th>
           <%= sort_order_link 'Surah', :chapter_id, recitation_id: @recitation.id %>

--- a/app/views/surah_audio_files/show.html.erb
+++ b/app/views/surah_audio_files/show.html.erb
@@ -24,7 +24,7 @@
   <div class="page-section">
     <h3>Segments list</h3>
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Verse', :verse_id, recitation_id: @recitation.id, chapter_id: params[:chapter_id] %></th>
         <th>From</th>

--- a/app/views/surah_infos/history.html.erb
+++ b/app/views/surah_infos/history.html.erb
@@ -5,7 +5,7 @@
 <div id="body">
   <div class="modal-body">
     <table class="table table-bordered">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <th>Date</th>
       <th>Event</th>
       <th>User</th>

--- a/app/views/surah_infos/index.html.erb
+++ b/app/views/surah_infos/index.html.erb
@@ -25,10 +25,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Surah list</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Surah list</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 tw-bg-white">
       <tr>
         <th><%= sort_order_link 'Surah', :chapter_id, resource_id: @resource.id %></th>
         <th>Language</th>
@@ -63,5 +63,3 @@
     </div>
   </div>
 </div>
-
-

--- a/app/views/tafsir_proofreadings/index.html.erb
+++ b/app/views/tafsir_proofreadings/index.html.erb
@@ -28,10 +28,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Tafsir</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Tafsir</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 tw-bg-white">
       <tr>
         <th><%= sort_order_link 'Id', :id, resource_id: @resource.id %></th>
         <th>Resource</th>

--- a/app/views/tajweed_words/_table.html.erb
+++ b/app/views/tajweed_words/_table.html.erb
@@ -1,5 +1,5 @@
 <table class="table table-hover mt-4">
-  <thead class="position-sticky bg-white border-bottom top-0">
+  <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
   <tr>
     <th>Word id</th>
     <th>IndoPak text</th>

--- a/app/views/tajweed_words/index.html.erb
+++ b/app/views/tajweed_words/index.html.erb
@@ -51,10 +51,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Words</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Words</h2>
     <div class= "tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Word index', :word_index %></th>
         <th>Location</th>

--- a/app/views/tajweed_words/rule_doc.html.erb
+++ b/app/views/tajweed_words/rule_doc.html.erb
@@ -39,7 +39,7 @@
     <h2>Sample words</h2>
 
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th>Location</th>
         <th>Text</th>

--- a/app/views/tajweed_words/show.html.erb
+++ b/app/views/tajweed_words/show.html.erb
@@ -56,7 +56,7 @@
     </h2>
 
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th>Index</th>
         <th>Letter</th>

--- a/app/views/tools/resources_view/_list.html.erb
+++ b/app/views/tools/resources_view/_list.html.erb
@@ -1,5 +1,5 @@
 <table class="tw-w-full">
-  <thead>
+  <thead class="tw-sticky tw-top-0 tw-z-10">
   <tr class="tw-border-b tw-bg-slate-100 tw-text-sm">
     <th class="tw-py-3 tw-px-4 tw-font-normal tw-min-w-48">
       <%= sort_order_link 'Tool', :name, {}, data: { turbo_action: 'advance' } %>

--- a/app/views/translation_diffs/index.html.erb
+++ b/app/views/translation_diffs/index.html.erb
@@ -7,7 +7,7 @@
   <div class="page-section mt-4">
     <h2>Exported translations</h2>
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th>Id</th>
         <th>Name</th>

--- a/app/views/translation_diffs/show.html.erb
+++ b/app/views/translation_diffs/show.html.erb
@@ -23,7 +23,7 @@
   <div class="page-section mt-4">
     <h2>Ayah diff</h2>
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th>Key</th>
         <th>Exported translation</th>

--- a/app/views/translation_proofreadings/index.html.erb
+++ b/app/views/translation_proofreadings/index.html.erb
@@ -31,7 +31,7 @@
     <h2><%= @resource.name %></h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Ayah key', :verse_key, resource_id: @resource.id %></th>
         <th>Footnotes</th>

--- a/app/views/word_concordance_labels/index.html.erb
+++ b/app/views/word_concordance_labels/index.html.erb
@@ -19,10 +19,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Ayah list</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Ayah list</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <th><%= sort_order_link 'Ayah#', :id %></th>
         <th>Key</th>

--- a/app/views/word_concordance_labels/show.html.erb
+++ b/app/views/word_concordance_labels/show.html.erb
@@ -28,7 +28,7 @@
 
     <h2>Words list</h2>
     <table class="table table-hover table-bordered">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <td>ID</td>
         <td style="direction: rtl">Text</td>

--- a/app/views/word_concordance_labels/word_detail.html.erb
+++ b/app/views/word_concordance_labels/word_detail.html.erb
@@ -83,7 +83,7 @@
     </h2>
 
     <table class="table table-hover table-bordered">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <td>Position</td>
         <td>Text</td>
@@ -136,7 +136,7 @@
     </h2>
 
     <table class="table table-hover table-bordered">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
       <tr>
         <td>Name</td>
         <td>Value</td>

--- a/app/views/word_text_proofreadings/index.html.erb
+++ b/app/views/word_text_proofreadings/index.html.erb
@@ -19,10 +19,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Ayah list</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Ayah list</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 tw-bg-white">
       <tr>
         <th><%= sort_order_link 'Ayah#', :id %></th>
         <th>Key</th>

--- a/app/views/word_text_proofreadings/show.html.erb
+++ b/app/views/word_text_proofreadings/show.html.erb
@@ -165,7 +165,7 @@
 
     <div style="max-height: 500px;overflow-y: auto;">
       <table class="table table-hover mt-4 table-bordered position-relative">
-        <thead class="position-sticky bg-white border-bottom top-0">
+        <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
         <tr class="bg-white border-bottom">
           <td>ID</td>
           <td style="direction: rtl">IndoPak</td>

--- a/app/views/word_translations/_table.html.erb
+++ b/app/views/word_translations/_table.html.erb
@@ -6,7 +6,7 @@
 %>
 
 <table class="table table-hover mt-4">
-  <thead class="position-sticky bg-white border-bottom top-0">
+  <thead class="tw-sticky tw-top-0 tw-z-10 bg-white border-bottom">
   <tr>
     <th>Word#</th>
     <th>Text Uthmani</th>

--- a/app/views/word_translations/index.html.erb
+++ b/app/views/word_translations/index.html.erb
@@ -31,10 +31,10 @@
   </div>
 
   <div class="page-section mt-4">
-    <h2>Ayahs</h2>
+    <h2 class="tw-text-2xl tw-mb-4">Ayahs</h2>
     <div class="tw-overflow-x-auto">
     <table class="table table-hover">
-      <thead class="position-sticky bg-white border-bottom top-0">
+      <thead class="tw-sticky tw-top-0 tw-z-10 tw-bg-white">
       <tr>
         <th><%= sort_order_link 'Ayah key', :verse_key %></th>
         <th>Progress</th>
@@ -85,5 +85,3 @@
     </div>
   </div>
 </div>
-
-


### PR DESCRIPTION
- Made table headers sticky (Resources/Tools)
- Fixed card height in grid layout (Resources)
- Prevented table header collapse on mobile (Resources)
- Updated title text size/color (Tools)
- Ensured all tables are responsive (Tools)