### PR TITLE
Fix: Eliminate audio repetition during Ayah transitions in Surah play

### DIFF
--- a/app/javascript/segments/components/SelectAudioSrc.vue
+++ b/app/javascript/segments/components/SelectAudioSrc.vue
@@ -58,7 +58,8 @@ export default {
         (state, getters) => state.currentAyahTimeFrom,
 
         (newValue, _) => {
-          if (newValue >= 0) {
+          // Only seek for individual ayah audio, not for complete surah audio
+          if (newValue >= 0 && this.$store.state.audioType === 'ayah') {
             player.currentTime = newValue / 1000;
           }
         },


### PR DESCRIPTION
This PR resolves the audio repetition glitch when a new ayah is started while playing a surah in segments tool.


### Without This PR
On next Ayah start, notice "Al" is repeated
https://github.com/user-attachments/assets/71d4c978-c0cb-4a77-ae49-54a679887d78


### With This PR
On next Ayah start, there is no repetition 
https://github.com/user-attachments/assets/c3c4c356-de72-4807-a590-65329d32af0f


