### PR TITLE
Fix: distinguish between automatic and manual ayah transitions for audio seeking

### DIFF
--- a/app/javascript/segments/components/SelectAudioSrc.vue
+++ b/app/javascript/segments/components/SelectAudioSrc.vue
@@ -58,8 +58,12 @@ export default {
         (state, getters) => state.currentAyahTimeFrom,
 
         (newValue, _) => {
-          // Only seek for individual ayah audio, not for complete surah audio
-          if (newValue >= 0 && this.$store.state.audioType === 'ayah') {
+          const shouldSeek = newValue >= 0 && (
+            this.$store.state.audioType === 'ayah' || 
+            this.$store.state.isManualAyahChange
+          );
+          
+          if (shouldSeek) {
             player.currentTime = newValue / 1000;
           }
         },

--- a/app/javascript/segments/store/index.js
+++ b/app/javascript/segments/store/index.js
@@ -59,7 +59,8 @@ const store = createStore({
       autoPlay: false,
       disableHotkeys: true,
 
-      repeatGroups: [] // only need for recitation 168
+      repeatGroups: [], // only need for recitation 168
+      isManualAyahChange: false
     };
   },
   getters: {},
@@ -122,6 +123,8 @@ const store = createStore({
       else verse = Number(payload.to);
 
       if (verse >= 1 || verse <= state.versesCount) {
+        state.isManualAyahChange = true;
+        
         state.currentVerseNumber = verse;
         state.currentTimestamp = 0;
         state.currentWord = 1;
@@ -530,6 +533,10 @@ const store = createStore({
             state.verseSegment.segments.push([index])
         }
       }
+      
+      setTimeout(() => {
+        state.isManualAyahChange = false;
+      }, 100);
     },
     LOAD_SEGMENTS({state}, payload) {
       const {


### PR DESCRIPTION
Adds `isManualAyahChange` flag to track navigation type to allow seeking for manual navigation (next/previous buttons, dropdown).

**Without this PR:**


https://github.com/user-attachments/assets/844f35e9-61f5-49e9-9bfd-4414fd835ad1


**With this PR:**

https://github.com/user-attachments/assets/28b96fa3-2545-4998-96cf-e559272ee16a

