### PR TITLE
Improve learning activities UI: remove redundant button, add titles, reset & retry options

### DIFF
--- a/app/javascript/controllers/activities/fill_the_blanks_controller.js
+++ b/app/javascript/controllers/activities/fill_the_blanks_controller.js
@@ -119,7 +119,21 @@ export default class extends ActivityController {
     }
   }
 
-  onSuccess() {
+    resetActivity() {
+        this.blankBoxes.forEach((blank) => {
+            blank.innerHTML = '';
+            blank.classList.remove('filled');
+            blank.dataset.filledId = '';
+        });
+
+        this.remainingWords.forEach((word) => {
+            word.classList.remove('d-none');
+            this.options.appendChild(word);
+        });
+    }
+
+
+    onSuccess() {
     super.onSuccess();
 
     this.blankBoxes.forEach((blank) => {

--- a/app/views/card/_card_footer.html.erb
+++ b/app/views/card/_card_footer.html.erb
@@ -21,11 +21,3 @@
 
   <%= render 'card/info-tip', tip: card.info_tip if card.respond_to?(:info_tip) && card.info_tip.present? %>
 </div>
-
-<% if local_assigns[:show_activity_cta] %>
-  <div class="tw-flex tw-items-center tw-justify-center tw-w-full tw-mt-8">
-    <div class="tw-text-center tw-bg-green-600 tw-text-white tw-py-2 tw-px-4 tw-w-full tw-font-semibold tw-rounded-lg">
-      <span>Let's go</span>
-    </div>
-  </div>
-<% end %>

--- a/app/views/learning_activities/_complete_the_ayah.html.erb
+++ b/app/views/learning_activities/_complete_the_ayah.html.erb
@@ -33,4 +33,8 @@
       </div>
     <% end %>
   </div>
+
+  <button type="button" data-action="click->activities--fill-in-blank#resetActivity" class="reset-btn btn btn-primary">
+    Reset
+  </button>
 </div>

--- a/app/views/learning_activities/_word_match.html.erb
+++ b/app/views/learning_activities/_word_match.html.erb
@@ -5,9 +5,7 @@
   right_translations = data[:right_translations]
 %>
 
-<h2 class="heading my-4 text-center fw-bold">Word Match</h2>
-
-<div class="quiz card shadow-lg p-4 rounded-3" data-controller="activities--word-match">
+<div class="quiz p-4 rounded-3" data-controller="activities--word-match">
   <div class="alert alert-info d-flex align-items-center gap-2 mb-4">
     <span class="fw-semibold">How to play:</span>
     <span>Drag a translation onto its Arabic word, or tap Select on each side to match a pair.</span>

--- a/app/views/learning_activities/show.html.erb
+++ b/app/views/learning_activities/show.html.erb
@@ -4,9 +4,11 @@
 %>
 <div class="tw-pt-32 tw-px-4 tw-pb-20 quiz-container overflow-auto">
   <div class="box">
+    <h1 class="h3"><%= activity.tr("_"," ").capitalize %></h1>
     <% if valid_activity?(activity) %>
       <%= set_page_title "#{activity.humanize} - Quranic quiz" %>
       <%= render activity %>
+      <%= link_to 'Try another', learning_activity_path(activity), class: 'btn btn-outline-dark me-3 my-3' %>
       <div class="result my-5" id="quiz-result">
         <div class="text-danger d-none" id="incorrect-message">
           Incorrect answer. Try again! You can also use Tarteel app to test your memorization. Download
@@ -22,7 +24,7 @@
       </div>
       <div class="more-activities d-flex justify-content-center gap-2 mt-4 d-none">
         <%= link_to 'Learn more about this ayah', '#_', class: 'btn btn-outline-success me-3 ayah-info', data: { controller: 'ajax-modal', url: '/ayah/1:1', css_class: 'modal-lg', use_turbo: true} %>
-        <%= link_to 'Try another', learning_activity_path(activity), class: 'btn btn-outline-dark me-3' %>
+        <%= link_to 'Next Challenge', learning_activity_path(activity), class: 'btn btn-outline-dark me-3' %>
         <%= link_to 'More learning activities', learning_activities_path, class: 'btn btn-outline-dark' %>
       </div>
     <% else %>


### PR DESCRIPTION
- Removed the "let's go" button from the cards on the learning activities page because we didn't need it. The navigation is already handled by clicking on the card, and these buttons don't match our overall app theme.

-  Add a title for each learning-activity page.

- Complete the Ayah page now has a functional reset button.

-  Every learning activity page now has a "try another" button so that users can attempt a different challenge if they are unable to finish an activity after trying it several times.