### PR TITLE
Allow user to change the word translations language

### DIFF
--- a/app/helpers/learning_activity_helper.rb
+++ b/app/helpers/learning_activity_helper.rb
@@ -51,19 +51,33 @@ module LearningActivityHelper
   end
 
   # Build data for Word Match activity: a list of arabic words and their translations
-  # Prefer English; if not available, fallback to Urdu
-  def generate_word_match_quiz
-    # Fetch random verses with moderate length to avoid very small stopwords-only sets
-    verses = Verse.where('words_count BETWEEN 4 AND 12').order('RANDOM()').limit(5)
-    words = Word.where(verse_id: verses.map(&:id), char_type_id: 1).includes(:en_translation, :ur_translation).sample(5)
+  # Prefer requested language; if not available, fallback to English, then any available
+  def generate_word_match_quiz(language_iso_code = 'en', word_ids = nil)
+    language = Language.find_by(iso_code: language_iso_code) || Language.find_by(iso_code: 'en')
+    english_language = Language.find_by(iso_code: 'en')
 
-    # Fallback in case previous query is sparse
-    if words.size < 5
-      words = Word.where(char_type_id: 1).includes(:en_translation, :ur_translation).order('RANDOM()').limit(5)
+    if word_ids.blank?
+      verses = Verse.where('words_count BETWEEN 4 AND 12').order('RANDOM()').limit(5)
+      words = Word.where(verse_id: verses.map(&:id), char_type_id: 1).includes(:word_translations).sample(5)
+
+      # Fallback in case previous query is sparse
+      if words.size < 5
+        words = Word.where(char_type_id: 1).includes(:word_translations).order('RANDOM()').limit(5)
+      end
+    else
+      words = Word.where(id: word_ids).includes(:word_translations)
     end
 
     pairs = words.map do |w|
-      translation = w.en_translation&.text.presence || w.ur_translation&.text.presence || w.word_translation&.text.presence || ''
+      # Try requested language first
+      translation = w.word_translations.detect { |t| t.language_id == language.id }&.text.presence
+
+      # Fallback to English if requested language not available
+      translation ||= w.word_translations.detect { |t| t.language_id == english_language.id }&.text.presence if english_language
+
+      # Final fallback to any available translation
+      translation ||= w.word_translations.first&.text.presence || ''
+
       {
         id: w.id,
         arabic: w.text_qpc_hafs,
@@ -75,6 +89,7 @@ module LearningActivityHelper
     pairs = pairs.select { |p| p[:translation].present? }
 
     {
+      word_ids: words.map(&:id),
       pairs: pairs,
       left_words: pairs.map { |p| { id: p[:id], text: p[:arabic] } },
       right_translations: pairs.map { |p| { id: p[:id], text: p[:translation] } }.shuffle

--- a/app/views/learning_activities/_word_match.html.erb
+++ b/app/views/learning_activities/_word_match.html.erb
@@ -1,5 +1,12 @@
 <%
-  data = generate_word_match_quiz
+  lang = params[:lang] || 'en'
+  if params[:new] == 'true'
+    session.delete(:word_match_word_ids)
+  end
+  word_ids = session[:word_match_word_ids]
+  data = generate_word_match_quiz(lang, word_ids)
+  session[:word_match_word_ids] = data[:word_ids]
+
   pairs = data[:pairs]
   left_words = data[:left_words]
   right_translations = data[:right_translations]
@@ -11,13 +18,13 @@
     <span>Click a black dot to start a line and connect it to the matching dot.</span>
   </div>
   <div class="d-flex flex-column flex-md-row gap-5 position-relative" id="match-area">
-    
+
     <!-- Arabic Column -->
     <div class="flex-fill">
-      <h3 class="mb-3 text-primary text-center tw-text-xl">Arabic</h5>
+      <h3 class="mb-3 text-primary text-center tw-text-xl">Arabic</h3>
       <div class="list-group border rounded shadow-sm" id="left-column">
         <% left_words.each do |w| %>
-          <div class="list-group-item d-flex align-items-center justify-content-between qpc-hafs rounded-2 mb-2 border-0 shadow-sm"
+          <div class="list-group-item d-flex align-items-center justify-content-between qpc-hafs rounded-2 mb-2 border-0 shadow-sm" style="min-height: 60px;"
                data-id="<%= w[:id] %>">
             <div class="d-flex align-items-center">
               <span class="anchor-dot ms-3 bg-secondary rounded-circle" data-side="left"></span>
@@ -34,7 +41,7 @@
       <h5 class="mb-3 text-success text-center tw-text-xl">Translations</h5>
       <div class="list-group border rounded shadow-sm" id="right-column">
         <% right_translations.each do |t| %>
-          <div class="list-group-item d-flex align-items-center justify-content-between rounded-2 mb-2 border-0 shadow-sm"
+          <div class="list-group-item d-flex align-items-center justify-content-between rounded-2 mb-2 border-0 shadow-sm" style="min-height: 60px;"
                data-id="<%= t[:id] %>">
             <div class="d-flex align-items-center">
               <span class="anchor-dot me-3 bg-secondary rounded-circle" data-side="right"></span>

--- a/app/views/learning_activities/show.html.erb
+++ b/app/views/learning_activities/show.html.erb
@@ -8,11 +8,11 @@
     <% if valid_activity?(activity) %>
       <%= set_page_title "#{activity.humanize} - Quranic quiz" %>
       <%= render activity %>
-      <%= link_to 'Try another', learning_activity_path(activity), class: 'btn btn-outline-dark me-3 my-3' %>
+      <%= link_to 'Try another', learning_activity_path(activity, new: true), class: 'btn btn-outline-dark me-3 my-3' %>
       <div class="result my-5" id="quiz-result">
         <div class="text-danger d-none" id="incorrect-message">
           Incorrect answer. Try again! You can also use Tarteel app to test your memorization. Download
-          <a class='text-danger' href="<%= tarteel_link %>" target="_blank">
+          <a class="text-danger" href="<%= tarteel_link %>" target="_blank">
             Tatreel app here
           </a> to test and improve your memorization.
         </div>
@@ -24,7 +24,7 @@
       </div>
       <div class="more-activities d-flex justify-content-center gap-2 mt-4 d-none">
         <%= link_to 'Learn more about this ayah', '#_', class: 'btn btn-outline-success me-3 ayah-info', data: { controller: 'ajax-modal', url: '/ayah/1:1', css_class: 'modal-lg', use_turbo: true} %>
-        <%= link_to 'Next Challenge', learning_activity_path(activity), class: 'btn btn-outline-dark me-3' %>
+        <%= link_to 'Next Challenge', learning_activity_path(activity, new: true), class: 'btn btn-outline-dark me-3' %>
         <%= link_to 'More learning activities', learning_activities_path, class: 'btn btn-outline-dark' %>
       </div>
     <% else %>

--- a/app/views/shared/not_found.html.erb
+++ b/app/views/shared/not_found.html.erb
@@ -16,7 +16,7 @@
       <div class="result my-5" id="quiz-result">
         <div class="text-danger d-none" id="incorrect-message">
           Incorrect answer. Try again! You can also use Tarteel app to test your memorization. Download
-          <a class='text-danger' href="<%= tarteel_link %>" target="_blank">
+          <a class="text-danger" href="<%= tarteel_link %>" target="_blank">
             Tatreel app here
           </a> to test and improve your memorization.
         </div>
@@ -30,7 +30,7 @@
 
       <div class="more-activities d-flex justify-content-center gap-2 mt-4 d-none">
         <%= link_to 'Learn more about this ayah', '#_', class: 'btn btn-outline-success me-3 ayah-info', data: { controller: 'ajax-modal', url: '/ayah/1:1', css_class: 'modal-lg', use_turbo: true} %>
-        <%= link_to 'Try another', learning_activity_path(activity), class: 'btn btn-outline-dark me-3' %>
+        <%= link_to 'Try another', learning_activity_path(activity, new: true), class: 'btn btn-outline-dark me-3' %>
         <%= link_to 'More learning activities', learning_activities_path, class: 'btn btn-outline-dark' %>
       </div>
     </div>


### PR DESCRIPTION
## Description

This pull request introduces the ability for users to change the language of word translations within match word activity. Previously, word translations were fixed to a default language, but with this update, users can select their preferred translation language.

### Key Features

- Updated backend logic to fetch translations according to the selected language.
- Persist user’s language choice for a personalized experience.

### Testing

- Verified language switching works .
- Ensured translations are fetched and displayed correctly.