### PR TITLE
Fix syntax errors in quran script preview template

### DIFF
--- a/app/views/resources/previews/_quran_script.html.erb
+++ b/app/views/resources/previews/_quran_script.html.erb
@@ -31,20 +31,47 @@
         <%= resource.name %> Preview
       </button>
     </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link"
+              id="tab-help"
+              data-bs-toggle="tab"
+              data-bs-target="#tab-help-pane"
+              type="button"
+              role="tab"
+              aria-controls="tab-help-pane"
+              aria-selected="false">
+        Help
+      </button>
+    </li>
+  </ul>
 
-<% if by_word %>
-  Preview of words from Surah <%= ayah.chapter.name_simple %>, Ayah <%= ayah.verse_number %>
-<% else %>
-  Surah <%= ayah.chapter.name_simple %> ayah <%= ayah.verse_number %>
-<% end %>
+  <div class="tab-content" id="quran-script-tab-content">
+    <div class="tab-pane fade show active"
+         id="tab-preview-pane"
+         role="tabpanel"
+         aria-labelledby="tab-preview" tabindex="0">
+      <div class="tw-mt-4">
+        <p class="tw-text-sm tw-text-gray-600 tw-mb-2">
+          <% if by_word %>
+            Preview of words from Surah <%= ayah.chapter.name_simple %>, Ayah <%= ayah.verse_number %>
+          <% else %>
+            Surah <%= ayah.chapter.name_simple %> ayah <%= ayah.verse_number %>
+          <% end %>
+        </p>
 
-<div class="tw-border tw-border-gray-300 tw-p-3 tw-text-center tw-rounded quran-text <%= script_class %>" data-controller="tajweed-highlight">
-  <% if by_word %>
-    <div class="tw-flex tw-flex-wrap tw-gap-2">
-      <% ayah.words.each_with_index do |word, index| %>
-        <span class="tw-px-4 tw-py-2 tw-border tw-border-gray-300 word">
-          <% if is_image %>
-            <img src="<%= word.read_attribute("#{text_type}_url") %>" alt="<%= word.location %>"/>
+        <div class="tw-border tw-border-gray-300 tw-p-3 tw-text-center tw-rounded quran-text <%= script_class %>" data-controller="tajweed-highlight">
+          <% if by_word %>
+            <div class="tw-flex tw-flex-wrap tw-gap-2">
+              <% ayah.words.each_with_index do |word, index| %>
+                <span class="tw-px-4 tw-py-2 tw-border tw-border-gray-300 word">
+                  <% if is_image %>
+                    <img src="<%= word.read_attribute("#{text_type}_url") %>" alt="<%= word.location %>"/>
+                  <% else %>
+                    <%= safe_html word.read_attribute(text_type) %>
+                  <% end %>
+                </span>
+              <% end %>
+            </div>
           <% else %>
             <% if is_image %>
               <div>


### PR DESCRIPTION
- Fixed mismatched HTML closing tags (span/div confusion)
- Removed duplicate nested is_image conditional inside else block
- Added proper tab structure with Help tab button
- Completed missing end tags for word loop and by_word conditional
- Added proper else clause for full ayah display when by_word is false
- Wrapped content in proper Bootstrap tab-content structure

This fixes the 500 Internal Server Error when accessing /resources/quran-script/37