### PR TITLE
Add Tailwind CSS support to ActiveAdmin and improve admin UI

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -12,6 +12,7 @@
 @import "admin/theme";
 @import "admin/dict";
 @import "admin/bootstrap";
+@import "admin/modal";
 @import "admin/active_admin_bootstrab_overrides";
 @import "libs/toastr";
 @import "components/common";

--- a/app/assets/stylesheets/admin/bootstrap.scss
+++ b/app/assets/stylesheets/admin/bootstrap.scss
@@ -11,6 +11,7 @@
 
 //@import 'bootstrap/scss/grid';
 @import 'bootstrap/scss/forms';
+@import 'bootstrap/scss/close';
 @import 'bootstrap/scss/modal';
 @import 'bootstrap/scss/list-group';
 @import 'bootstrap/scss/list-group';

--- a/app/assets/stylesheets/admin/modal.scss
+++ b/app/assets/stylesheets/admin/modal.scss
@@ -102,7 +102,10 @@
 .modal-body {
   position: relative;
   flex: 1 1 auto;
-  padding: 1rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .modal-footer {

--- a/app/javascript/controllers/ajax_modal_controller.js
+++ b/app/javascript/controllers/ajax_modal_controller.js
@@ -95,10 +95,10 @@ export default class extends Controller {
       <div class="modal-dialog modal-dialog-centered ${classes}">
         <div class="modal-content" id="modal-content">
           <div class="modal-header" id="modal-header">
-            <h5 class="modal-title" id="title">Loading</h5>
+            <h5 class="modal-title mt-0" id="title">Loading</h5>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
-          <div id="modal-body">
+          <div id="modal-body" class="px-2">
           <div class="modal-body">
             Loading
           </div>

--- a/app/views/admin/_download_gapped_segments.html.erb
+++ b/app/views/admin/_download_gapped_segments.html.erb
@@ -5,7 +5,7 @@
 <div id="body">
   <%= form_with url: download_segments_cms_recitation_path(resource), method: :put, data: {turbo: false} do |form| %>
     <div class="tw-p-6">
-      <div class="tw-mb-4 tw-mb-2">
+      <div class="tw-mb-2">
         <%= form.label :chapter_id, 'Select chapter', class: 'form-label' %>
         <%= form.select :chapter_id, Chapter.order('id asc').map { |c| [c.humanize, c.id] }, { include_blank: 'Select chapter' }, class: 'form-control', data: { controller: 'select2', parent: '#ajax-modal', placeholder: 'select chapter' } %>
         <div class="help-block">
@@ -13,7 +13,7 @@
         </div>
       </div>
 
-      <div class="tw-mb-4 tw-mb-2">
+      <div class="tw-mb-2">
         <%= form.label :export_format, 'Select format', class: 'form-label' %>
         <%= form.select :export_format, [['Sqlite db', 'db'], ['CSV', 'csv']], {}, class: 'form-control', data: { controller: 'select2', parent: '#ajax-modal', placeholder: 'select format' } %>
       </div>

--- a/app/views/admin/_download_segments.html.erb
+++ b/app/views/admin/_download_segments.html.erb
@@ -5,7 +5,7 @@
 <div id="body">
   <%= form_with url: download_segments_cms_audio_recitation_path(resource), method: :put, data: {turbo: false} do |form| %>
     <div class="tw-p-6">
-      <div class="tw-mb-4 tw-mb-2">
+      <div class="tw-mb-2">
         <%= form.label :chapter_id, 'Select chapter', class: 'form-label' %>
         <%= form.select :chapter_id, Chapter.order('id asc').map { |c| [c.humanize, c.id] }, { include_blank: 'Select chapter' }, class: 'form-control', data: { controller: 'select2', parent: '#ajax-modal', placeholder: 'select chapter' } %>
         <div class="help-block">
@@ -13,13 +13,13 @@
         </div>
       </div>
 
-      <div class="tw-mb-4 tw-mb-2">
+      <div class="tw-mb-2">
         <%= form.label :export_format, 'Select format', class: 'form-label' %>
         <%= form.select :export_format, [['Sqlite db', 'db'], ['JSON', 'json'], ['CSV', 'csv']], {}, class: 'form-control', data: { controller: 'select2', parent: '#ajax-modal', placeholder: 'select format' } %>
       </div>
     </div>
 
-    <div class="tw-flex tw-items-center tw-justify-end tw-p-6 tw-border-t tw-border-gray-200 tw-space-x-2">
+    <div class="tw-flex tw-items-center tw-justify-end my-2 tw-p-6 tw-border-t tw-border-gray-200 tw-space-x-2">
       <%= form.submit 'Download', class: 'btn btn-success' %>
     </div>
   <% end %>

--- a/app/views/admin/_upload_segments.html.erb
+++ b/app/views/admin/_upload_segments.html.erb
@@ -1,4 +1,4 @@
-<div id=title>
+<div id="title" class="tw-text-xl tw-font-semibold tw-text-gray-800">
   Upload segments for <%= resource.name %>
 </div>
 
@@ -18,22 +18,22 @@
           Segments are locked for this recitation. Please unlock the segments and try again.
         </div>
       <% else %>
-        <div class="tw-mb-4 tw-mb-2">
-          <div class="tw-flex tw-items-center tw-mb-2">
-            <%= form.check_box :remove_existing, class: 'form-check-input' %>
-            <%= form.label :remove_existing, 'Remove existing segments?', class: 'form-check-label' %>
-          </div>
+        <div class="tw-mb-4 tw-my-2">
+          <%= form.label :remove_existing, class: "tw-flex tw-items-center tw-gap-2 tw-cursor-pointer" do %>
+            <%= form.check_box :remove_existing, class: "tw-w-4 tw-h-4 tw-rounded tw-border-gray-300 tw-text-blue-600 focus:tw-ring-blue-500" %>
+            <span class="tw-text-gray-700">Remove existing segments?</span>
+          <% end %>
         </div>
-        <div class="tw-mb-4 tw-mb-2">
-          <%= form.label :file, 'Select timing db file' %>
-          <%= form.file_field :file, class: 'form-control' %>
+        <div class="tw-mb-4 tw-my-2">
+          <%= form.label :file, 'Select timing db file', class: 'tw-block tw-text-gray-700 tw-font-medium tw-mb-2' %>
+          <%= form.file_field :file, class: 'tw-w-full tw-border tw-border-gray-300 tw-rounded tw-px-3 tw-py-2 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-blue-500 focus:tw-border-transparent' %>
         </div>
       <% end %>
     </div>
 
     <% if !resource.segment_locked? %>
       <div class="tw-flex tw-items-center tw-justify-end tw-p-6 tw-border-t tw-border-gray-200 tw-space-x-2">
-        <%= form.submit 'Upload', class: 'btn btn-success' %>
+        <%= form.submit 'Upload', class: 'tw-bg-green-600 tw-text-white tw-px-6 tw-py-2 tw-rounded tw-font-medium hover:tw-bg-green-700 focus:tw-outline-none focus:tw-ring-2 focus:tw-ring-green-500 focus:tw-ring-offset-2 tw-transition-colors tw-cursor-pointer' %>
       </div>
     <% end %>
   <% end %>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -189,6 +189,7 @@ ActiveAdmin.setup do |config|
   #
   # To load a stylesheet:
   #   config.register_stylesheet 'my_stylesheet.css'
+  config.register_stylesheet 'tailwind'
   config.register_stylesheet 'tinymce_custom', id: 'tinymce_custom_style'
   config.register_stylesheet 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css'
 


### PR DESCRIPTION
- Register Tailwind stylesheet in ActiveAdmin initializer
- Update admin modal styles to import modal.scss
- Style upload segments form with Tailwind classes
- Update checkbox, file input, and submit button with Tailwind styling
- Improve form labels and input field appearance
- Add consistent spacing and color scheme across admin forms

<img width="1920" height="949" alt="image" src="https://github.com/user-attachments/assets/734ca4a2-637a-4a4e-b09a-c283ea9046d5" />
