### PR TITLE
Fix modal Bootstrap conflict on form submission

### DIFF
--- a/app/javascript/controllers/ajax_modal_controller.js
+++ b/app/javascript/controllers/ajax_modal_controller.js
@@ -162,6 +162,11 @@ export default class extends Controller {
     };
     document.addEventListener('keydown', this.escapeHandler);
 
+    this.closeEventHandler = () => {
+      this.hide();
+    };
+    document.addEventListener('ajax-modal:close', this.closeEventHandler);
+
     document.body.style.overflow = 'hidden';
 
     modal.addEventListener('click', (e) => {
@@ -224,6 +229,10 @@ export default class extends Controller {
       if (this.escapeHandler) {
         document.removeEventListener('keydown', this.escapeHandler);
         this.escapeHandler = null;
+      }
+      if (this.closeEventHandler) {
+        document.removeEventListener('ajax-modal:close', this.closeEventHandler);
+        this.closeEventHandler = null;
       }
       document.body.style.overflow = '';
     }, 300);

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
   </head>
 
   <body class="tw-font-inter" data-controller="event-tracker">
+    <div id="turbo-script-container" class="tw-hidden"></div>
     <%= render 'shared/flash_notices' %>
     <%= render 'landing/header' %>
     <%= yield %>

--- a/app/views/mushaf_layouts/_page_mapping_modal.html.erb
+++ b/app/views/mushaf_layouts/_page_mapping_modal.html.erb
@@ -54,7 +54,7 @@
 
               <div class="tw-flex tw-gap-2 tw-justify-end tw-pt-3">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <%= form.submit 'Save', id: 'submit', class: 'btn btn-primary', disabled: !@access, data: { bs_dismiss: 'modal' } %>
+                <%= form.submit 'Save', id: 'submit', class: 'btn btn-primary', disabled: !@access %>
               </div>
             </div>
           <% end %>

--- a/app/views/mushaf_layouts/save_page_mapping.turbo_stream.erb
+++ b/app/views/mushaf_layouts/save_page_mapping.turbo_stream.erb
@@ -27,3 +27,10 @@
 <%= turbo_stream.replace 'flash-messages' do %>
   <%= render 'shared/flash_notices' %>
 <% end %>
+
+<%= turbo_stream.append "turbo-script-container" do %>
+  <script>
+    document.dispatchEvent(new CustomEvent('ajax-modal:close'));
+    this.parentElement.removeChild(this);
+  </script>
+<% end %>


### PR DESCRIPTION
- Remove data-bs-dismiss attribute from submit button to prevent Bootstrap modal initialization
- Add script tag in Turbo stream response to dispatch custom close event
- Update ajax_modal_controller to listen for ajax-modal:close event
- Add hidden script container in layout for Turbo stream script execution
- Modal now closes properly after successful form submission