### PR TITLE
Refactor alert dismissal to use Stimulus exclusively

### DIFF
--- a/app/javascript/controllers/alert_controller.js
+++ b/app/javascript/controllers/alert_controller.js
@@ -1,25 +1,11 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  connect() {
-    // Find and attach click handler to close button
-    const closeButton = this.element.querySelector('[data-bs-dismiss="alert"]');
-    if (closeButton) {
-      closeButton.addEventListener('click', () => {
-        this.close();
-      });
-    }
-  }
-
-  close() {
-    // Fade out the alert
+  close(event) {
+    event.preventDefault()
     this.element.style.transition = 'opacity 0.15s linear';
     this.element.style.opacity = '0';
-    
-    // Remove the alert after fade out
-    setTimeout(() => {
-      this.element.remove();
-    }, 150);
+    setTimeout(() => this.element.remove(), 150);
   }
 }
 

--- a/app/views/shared/_access_message.html.erb
+++ b/app/views/shared/_access_message.html.erb
@@ -5,7 +5,7 @@
         <div class="tw-w-full">
           <div style="font-size: 30px; margin-top: 10px">
             <%= safe_html @access.admin_notes %>
-            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+            <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
           </div>
         </div>
       </div>

--- a/app/views/tools/header_alert/_arabic_transliteration.html.erb
+++ b/app/views/tools/header_alert/_arabic_transliteration.html.erb
@@ -21,6 +21,6 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>
 

--- a/app/views/tools/header_alert/_ayah_recitation.html.erb
+++ b/app/views/tools/header_alert/_ayah_recitation.html.erb
@@ -20,5 +20,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_ayah_tafsir.html.erb
+++ b/app/views/tools/header_alert/_ayah_tafsir.html.erb
@@ -20,5 +20,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_ayah_translation.html.erb
+++ b/app/views/tools/header_alert/_ayah_translation.html.erb
@@ -20,5 +20,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_char.html.erb
+++ b/app/views/tools/header_alert/_char.html.erb
@@ -12,5 +12,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close ms-auto" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_corpus.html.erb
+++ b/app/views/tools/header_alert/_corpus.html.erb
@@ -12,5 +12,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close ms-auto" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_mushaf_layout.html.erb
+++ b/app/views/tools/header_alert/_mushaf_layout.html.erb
@@ -27,5 +27,5 @@
     <% end %>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_mushaf_layouts.html.erb
+++ b/app/views/tools/header_alert/_mushaf_layouts.html.erb
@@ -12,5 +12,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close ms-auto" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_mutashabihat.html.erb
+++ b/app/views/tools/header_alert/_mutashabihat.html.erb
@@ -23,5 +23,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_quran_script.html.erb
+++ b/app/views/tools/header_alert/_quran_script.html.erb
@@ -13,5 +13,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_quran_scripts_comparison.html.erb
+++ b/app/views/tools/header_alert/_quran_scripts_comparison.html.erb
@@ -13,6 +13,6 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close ms-auto" data-action="click->alert#close" aria-label="Close"></button>
 </div>
 

--- a/app/views/tools/header_alert/_surah_info.html.erb
+++ b/app/views/tools/header_alert/_surah_info.html.erb
@@ -20,5 +20,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_surah_recitation.html.erb
+++ b/app/views/tools/header_alert/_surah_recitation.html.erb
@@ -20,5 +20,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close" data-action="click->alert#close" aria-label="Close"></button>
 </div>

--- a/app/views/tools/header_alert/_word_translation.html.erb
+++ b/app/views/tools/header_alert/_word_translation.html.erb
@@ -20,5 +20,5 @@
     </p>
   </div>
 
-  <button type="button" class="btn-close ms-auto" data-bs-dismiss="alert" aria-label="Close"></button>
+  <button type="button" class="btn-close ms-auto" data-action="click->alert#close" aria-label="Close"></button>
 </div>


### PR DESCRIPTION
- Remove all data-bs-dismiss='alert' attributes from alert components
- Replace with Stimulus actions (data-action='click->alert#close')
- Rewrite alert_controller.js to handle dismissal via Stimulus actions
- Eliminate Bootstrap alert plugin involvement to prevent race conditions
- Fixes TypeError: Cannot read properties of null (reading 'defaultPrevented')