### PR TITLE
Add tip on installing the correct Bundler version

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ gem install bundler
 bundle install
 ```
 
+* **Tip:** To prevent Bundler from reinstalling due to a version mismatch, you can install the specific version listed under `BUNDLED_WITH` in `Gemfile.lock` using the command `gem install bundler -v [version]`
+
 #### 5. Database Configuration
 
 **QUL requires two databases:**


### PR DESCRIPTION
I followed the Setup Guide and found out that the `gem install bundler` would install the latest version but it turned out that Bundler is locked at version 2.5.15. This additional tip will save a little bit of time by avoiding re-downloading Bundler.