### PR TITLE
Fix tools grid layout: equal card heights and responsive icons

### DIFF
--- a/app/views/card/_card-container.erb
+++ b/app/views/card/_card-container.erb
@@ -8,7 +8,7 @@
 %>
 
 <%= content_tag tag_name, class: "tw-w-full tw-inline-block tw-transition-transform tw-duration-300 hover:tw-scale-[1.02] tw-group", **href_attr, data: data_attrs  do %>
-  <div class="tw-relative tw-rounded-3xl md:tw-rounded-[45px] tw-h-auto tw-min-h-[500px] md:tw-h-[550px] tool-card-with-bg tw-px-6 md:tw-px-8 tw-py-6 tw-shadow-xl hover:tw-shadow-2xl tw-transition-all tw-duration-300 <%= "#{card_type} pattern#{pattern}" %>">
+  <div class="tw-relative tw-rounded-3xl md:tw-rounded-[45px] tw-h-full tool-card-with-bg tw-px-6 md:tw-px-8 tw-py-6 tw-shadow-xl hover:tw-shadow-2xl tw-transition-all tw-duration-300 <%= "#{card_type} pattern#{pattern}" %>">
     <div class="overlay tw-opacity-90 group-hover:tw-opacity-85 tw-transition-opacity tw-duration-300"></div>
     <%= yield %>
   </div>

--- a/app/views/card/_card_content.html.erb
+++ b/app/views/card/_card_content.html.erb
@@ -17,7 +17,7 @@
       </div>
     <% end %>
 
-    <div class="tw-flex tw-flex-col tw-items-center tw-justify-center tw-flex-grow tw-min-h-[200px] md:tw-min-h-[250px]">
+    <div class="tw-flex tw-flex-col tw-items-center tw-justify-center tw-flex-grow">
       <% if local_assigns[:is_quran_script] %>
         <%= render 'quran_script_preview',
                    resource: card.resource_content,
@@ -27,7 +27,7 @@
         <div class="tw-flex tw-items-center tw-justify-center tw-w-full tw-transform group-hover:tw-scale-105 tw-transition-transform tw-duration-300">
           <% if card.respond_to?(:icon) && card.icon.present? %>
             <% if card.icon.start_with?('fa-') %>
-              <i class="fa tw-text-white tw-text-[150px] md:tw-text-[180px] lg:tw-text-[200px] <%= card.icon %> tw-opacity-90 group-hover:tw-opacity-100 tw-transition-opacity"></i>
+              <i class="fa tw-text-white tw-text-8xl md:tw-text-9xl <%= card.icon %> tw-opacity-90 group-hover:tw-opacity-100 tw-transition-opacity"></i>
             <% else %>
               <%= image_tag "card-icon/#{card.icon}", alt: "#{card.name || card.title} icon", class: "tw-max-w-full tw-h-auto tw-opacity-90 group-hover:tw-opacity-100 tw-transition-opacity" %>
             <% end %>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1920" height="908" alt="Before" src="https://github.com/user-attachments/assets/b24db800-4dee-4808-8ae1-fd5a074505f1" /> | <img width="1920" height="908" alt="After" src="https://github.com/user-attachments/assets/2598bc00-10fb-478c-a421-6d76e33cb28d" /> |
