### PR TITLE
Migrate database backup uploader from CarrierWave to ActiveStorage #1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,8 +111,9 @@ group :development do
   gem "letter_opener"
 end
 
-gem 'carrierwave', '~> 2.2.6'
-gem 'fog-aws'
+# Removed CarrierWave - migrated to ActiveStorage
+# gem 'carrierwave', '~> 2.2.6'
+# gem 'fog-aws'
 
 gem 'rest-client'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,14 +120,6 @@ GEM
       msgpack (~> 1.2)
     builder (3.3.0)
     cancancan (3.4.0)
-    carrierwave (2.2.6)
-      activemodel (>= 5.0.0)
-      activesupport (>= 5.0.0)
-      addressable (~> 2.6)
-      image_processing (~> 1.1)
-      marcel (~> 1.0.0)
-      mini_mime (>= 0.1.3)
-      ssrf_filter (~> 1.0)
     chartkick (5.1.5)
     chronic_duration (0.10.6)
       numerizer (~> 0.1.1)
@@ -164,7 +156,6 @@ GEM
       tzinfo
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    excon (0.92.3)
     execjs (2.8.1)
     faraday (1.10.0)
       faraday-em_http (~> 1.0)
@@ -194,22 +185,6 @@ GEM
     ffi (1.16.3)
     ffi-hunspell (0.6.1)
       ffi (~> 1.0)
-    fog-aws (3.14.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-    fog-core (2.3.0)
-      builder
-      excon (~> 0.71)
-      formatador (>= 0.2, < 2.0)
-      mime-types
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
-    fog-xml (0.1.4)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
-    formatador (1.1.0)
     formtastic (5.0.0)
       actionpack (>= 6.0.0)
     formtastic_i18n (0.7.0)
@@ -528,7 +503,6 @@ GEM
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
-    ssrf_filter (1.1.2)
     stackprof (0.2.26)
     stimulus-rails (1.0.4)
       railties (>= 6.0.0)
@@ -603,7 +577,6 @@ DEPENDENCIES
   benchmark-ips
   bootsnap (>= 1.4.4)
   cancancan
-  carrierwave (~> 2.2.6)
   chartkick
   cld3 (~> 3.6)
   concurrent-ruby (= 1.3.4)
@@ -618,7 +591,6 @@ DEPENDENCIES
   engtagger
   escompress (~> 1.0)
   ffi-hunspell
-  fog-aws
   groupdate
   image_processing
   inline_svg (~> 1.10)

--- a/app/admin/database_backup.rb
+++ b/app/admin/database_backup.rb
@@ -49,7 +49,13 @@ ActiveAdmin.register DatabaseBackup do
     column :tag
     column :size
     column :download do |backup|
-      link_to 'Download', backup.file.url
+      if backup.backup_file.attached?
+        link_to 'Download', rails_blob_path(backup.backup_file, disposition: 'attachment')
+      elsif backup.file.present?
+        link_to 'Download', backup.file.url
+      else
+        'No file'
+      end
     end
   end
 

--- a/app/models/database_backup.rb
+++ b/app/models/database_backup.rb
@@ -13,5 +13,18 @@
 #
 
 class DatabaseBackup < ApplicationRecord
-  mount_uploader :file, DatabaseBackupUploader
+  has_one_attached :backup_file, service: :database_backups
+
+  # Backward compatibility for transition period
+  # mount_uploader :file, DatabaseBackupUploader
+
+  def file_url
+    if backup_file.attached?
+      Rails.application.routes.url_helpers.rails_blob_path(backup_file, only_path: true)
+    elsif file.present?
+      DatabaseBackupUploader.new.url(file)
+    end
+  end
+
+  alias_method :url, :file_url
 end

--- a/app/models/resource_content.rb
+++ b/app/models/resource_content.rb
@@ -146,8 +146,8 @@ class ResourceContent < QuranApiRecord
               :export_format,
               :export_file_name
 
-  # TODO: replace uploader with ActiveStorage
-  mount_uploader :sqlite_db, DatabaseBackupUploader
+  has_one_attached :sqlite_database, service: :database_backups
+  # mount_uploader :sqlite_db, DatabaseBackupUploader
   has_many_attached :source_files
 
   module CardinalityType

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -1,7 +1,10 @@
-require 'fog/aws'
-require 'carrierwave/storage/fog'
+# frozen_string_literal: true
+# Deprecated: Replaced with ActiveStorage
+# require 'fog/aws'
+# require 'carrierwave/storage/fog'
 
-CarrierWave.configure do |config|
+if defined?(CarrierWave)
+  CarrierWave.configure do |config|
   if %[development test].include?(Rails.env)
     config.storage = :file
   else
@@ -19,6 +22,7 @@ CarrierWave.configure do |config|
     config.fog_directory  = ENV.fetch('DB_BACK_BUCKET'){'db-backups'}            # required
     config.fog_public     = false                                                 # optional, defaults to true
     config.fog_attributes = { cache_control: "public, max-age=#{2.days.to_i}" } # optional, defaults to {}
+  end
   end
 end
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -64,3 +64,15 @@ qul_segments:
   endpoint: <%= ENV.fetch('QUL_STORAGE_ENDPOINT'){'https://fix.me'} %>
   upload:
     cache_control: "private, max-age=0"
+
+# Database backups storage (S3-compatible)
+database_backups:
+  service: S3
+  access_key_id: <%= ENV.fetch('AWS_ACCESS_KEY'){'missing'} %>
+  secret_access_key: <%= ENV.fetch('AWS_ACCESS_KEY_SECRET'){'missing'} %>
+  region: <%= ENV.fetch('DB_BACKUP_REGION'){'us-east-2'} %>
+  bucket: <%= ENV.fetch('DB_BACK_BUCKET'){'db-backups'} %>
+  public: false
+  <%= "endpoint: #{ENV['DB_BACKUP_ENDPOINT']}" if ENV['DB_BACKUP_ENDPOINT'].present? %>
+  upload:
+    cache_control: "private, max-age=<%= 2.days.to_i %>"

--- a/lib/utils/db_backup.rb
+++ b/lib/utils/db_backup.rb
@@ -44,19 +44,28 @@ module Utils
     end
 
     def upload(tag)
-      # Upload file to google cloud storage
       backup = DatabaseBackup.new(database_name: backup_name)
       backup.size = number_to_human_size(File.size(dump_file_name))
-      backup.file = Rails.root.join(dump_file_name).open
       backup.tag = tag
+
+      backup.backup_file.attach(
+        io: File.open(dump_file_name),
+        filename: File.basename(dump_file_name),
+        content_type: 'application/x-bzip2'
+      )
 
       backup.save
 
       if export_binary?
         binary_backup = DatabaseBackup.new(database_name: "#{backup_name}_binary")
         binary_backup.size = number_to_human_size(File.size(binary_dump_file_name))
-        binary_backup.file = Rails.root.join(binary_dump_file_name).open
         binary_backup.tag = tag
+
+        binary_backup.backup_file.attach(
+          io: File.open(binary_dump_file_name),
+          filename: File.basename(binary_dump_file_name),
+          content_type: 'application/x-bzip2'
+        )
 
         binary_backup.save
       end


### PR DESCRIPTION
This pull request migrates database backup file uploads from CarrierWave to ActiveStorage while also maintaining backward compatibility during this transition period. This fixes issue #1.

**Changes**:

- [`Gemfile`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-d09ea66f8227784ff4393d88a19836f321c915ae10031d16c93d67e6283ab55f) - Removed `carrierwave` and `fog-aws` dependencies (replaced by native ActiveStorage)
- [`app/models/database_backup.rb`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-02268b9304b3dc67db3c9f3d4d5b5766492e50c504f1d3c1c923949d2c17aa7a) - Added `has_one_attached :backup_file` with backward compatibility methods for transitioning from CarrierWave
- [`app/models/resource_content.rb`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-f66f3a6a217b5d299107cfe66750106118a8f2e6ff5d8fe60e7fabfeb10ccf23) - Added `has_one_attached :sqlite_database` for SQLite database file attachments
- [`lib/utils/db_backup.rb`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-615b9d7ac6479d48647159f313a0dfd2bcb6b1b9b3dd7559f886c72809d49801) - Updated upload logic to use `backup_file.attach()` API instead of CarrierWave file assignment
- [`app/admin/database_backup.rb`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-00680cc9afd7ed4170c5727d8082a075a90f445969d6bebb6d66d8919b235c52) - Updated download links to support both ActiveStorage and legacy CarrierWave files during transition
- [`config/storage.yml`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-188abe2a4493506d81577fbbee0b279b889e59f50d509402fbbfb620c8e58780) - Added `database_backups` S3-compatible storage service with conditional Wasabi endpoint support
- [`config/initializers/carrier_wave.rb`](https://github.com/TarteelAI/quranic-universal-library/pull/506/files#diff-06912480fc37a3b5e2cd5de94965e34859e5a9f8b3f562da9ed6054a4538d399) - Disabled CarrierWave configuration (kept for backward compatibility during transition)