### PR TITLE
feat: enhance Ayah modal UI with search, grouping, and consistent displays

### DIFF
--- a/app/javascript/controllers/ayah_translation_selector_controller.js
+++ b/app/javascript/controllers/ayah_translation_selector_controller.js
@@ -2,7 +2,15 @@ import { Controller } from "@hotwired/stimulus";
 import { getAyahModalPrefs, setAyahModalPrefs } from "../lib/ayah_modal_store";
 
 export default class extends Controller {
-  static targets = ["panel", "backdrop", "form"];
+  static targets = [
+    "panel",
+    "backdrop",
+    "form",
+    "search",
+    "translationList",
+    "chevron",
+    "groupContent",
+  ];
 
   connect() {
     const prefs = getAyahModalPrefs();
@@ -14,7 +22,9 @@ export default class extends Controller {
     }
     if (prefs.translationIds && prefs.translationIds.length) {
       const current = this.currentTranslationIds();
-      const desired = prefs.translationIds.map((x) => parseInt(x, 10)).filter((x) => Number.isInteger(x));
+      const desired = prefs.translationIds
+        .map((x) => parseInt(x, 10))
+        .filter((x) => Number.isInteger(x));
       if (!this.sameIds(current, desired)) {
         this.setTranslationIds(desired);
         if (this.formTarget) this.formTarget.requestSubmit();
@@ -38,24 +48,32 @@ export default class extends Controller {
     this.panelTarget.classList.remove("tw-flex");
     this.backdropTarget.classList.add("tw-hidden");
     this.backdropTarget.classList.remove("tw-block");
+    // Submit form when closing to save translation selections
+    if (this.formTarget) this.formTarget.requestSubmit();
   }
 
   change() {
     const ids = this.currentTranslationIds();
     setAyahModalPrefs({ translationIds: ids });
-    if (this.formTarget) this.formTarget.requestSubmit();
+    // Removed form submission to prevent dropdown collapse during selection
   }
 
   currentTranslationIds() {
     if (!this.formTarget) return [];
-    const inputs = this.formTarget.querySelectorAll('input[name="translation_ids[]"]:checked');
-    return Array.from(inputs).map((i) => parseInt(i.value, 10)).filter((x) => Number.isInteger(x));
+    const inputs = this.formTarget.querySelectorAll(
+      'input[name="translation_ids[]"]:checked',
+    );
+    return Array.from(inputs)
+      .map((i) => parseInt(i.value, 10))
+      .filter((x) => Number.isInteger(x));
   }
 
   setTranslationIds(ids) {
     if (!this.formTarget) return;
     const set = new Set(ids.map((x) => x.toString()));
-    const inputs = this.formTarget.querySelectorAll('input[name="translation_ids[]"]');
+    const inputs = this.formTarget.querySelectorAll(
+      'input[name="translation_ids[]"]',
+    );
     inputs.forEach((i) => {
       i.checked = set.has(i.value);
     });
@@ -71,6 +89,105 @@ export default class extends Controller {
     }
     return true;
   }
+
+  search() {
+    const query = this.searchTarget.value.toLowerCase();
+    const items =
+      this.translationListTarget.querySelectorAll(".translation-item");
+    const groups =
+      this.translationListTarget.querySelectorAll(".translation-group");
+
+    if (query === "") {
+      // Show all items and groups when search is empty
+      items.forEach((item) => (item.style.display = ""));
+      groups.forEach((group) => (group.style.display = ""));
+      return;
+    }
+
+    // Find groups that match the search query (language names)
+    const matchingGroups = [];
+    groups.forEach((group) => {
+      const language = group.dataset.language;
+      if (language && language.includes(query)) {
+        matchingGroups.push(group);
+      }
+    });
+
+    // If any groups match the query (language search), show all items in those groups
+    if (matchingGroups.length > 0) {
+      items.forEach((item) => {
+        const parentGroup = item.closest(".translation-group");
+        const isInMatchingGroup = matchingGroups.includes(parentGroup);
+        item.style.display = isInMatchingGroup ? "" : "none";
+      });
+
+      groups.forEach((group) => {
+        const isMatching = matchingGroups.includes(group);
+        group.style.display = isMatching ? "" : "none";
+
+        // Expand matching groups
+        if (isMatching) {
+          const groupContent = group.querySelector(
+            '[data-ayah-translation-selector-target="groupContent"]',
+          );
+          if (groupContent) {
+            groupContent.classList.remove("tw-hidden");
+            const chevron = group.querySelector(
+              '[data-ayah-translation-selector-target="chevron"]',
+            );
+            if (chevron) chevron.style.transform = "rotate(180deg)";
+          }
+        }
+      });
+    } else {
+      // No groups match, filter individual items by name
+      items.forEach((item) => {
+        const name = item.dataset.name;
+        const matches = name.includes(query);
+        item.style.display = matches ? "" : "none";
+      });
+
+      // Hide groups that have no visible items
+      groups.forEach((group) => {
+        const visibleItems = group.querySelectorAll(
+          '.translation-item[style=""], .translation-item:not([style*="none"])',
+        );
+        group.style.display = visibleItems.length > 0 ? "" : "none";
+
+        // If group is visible and has matching items, expand it
+        if (visibleItems.length > 0) {
+          const groupContent = group.querySelector(
+            '[data-ayah-translation-selector-target="groupContent"]',
+          );
+          if (groupContent) {
+            groupContent.classList.remove("tw-hidden");
+            const chevron = group.querySelector(
+              '[data-ayah-translation-selector-target="chevron"]',
+            );
+            if (chevron) chevron.style.transform = "rotate(180deg)";
+          }
+        }
+      });
+    }
+  }
+
+  toggleGroup(event) {
+    const button = event.currentTarget;
+    const group = button.dataset.group;
+    const content = this.groupContentTargets.find(
+      (target) => target.dataset.group === group,
+    );
+    const chevron = this.chevronTargets.find(
+      (target) => target.dataset.group === group,
+    );
+
+    if (content) {
+      content.classList.toggle("tw-hidden");
+    }
+
+    if (chevron) {
+      const isExpanded = !content.classList.contains("tw-hidden");
+      chevron.style.transform = isExpanded ? "rotate(180deg)" : "rotate(0deg)";
+    }
+  }
 }
-
-

--- a/app/presenters/ayah_presenter.rb
+++ b/app/presenters/ayah_presenter.rb
@@ -57,6 +57,12 @@ class AyahPresenter < ApplicationPresenter
     @translation_resources_by_id ||= translation_resources.index_by(&:id)
   end
 
+  def translation_resources_grouped_by_language
+    @translation_resources_grouped_by_language ||= translation_resources.includes(:language).group_by do |resource|
+      resource.language&.name&.titleize || 'Unknown'
+    end.sort_by { |language, _| language }.to_h
+  end
+
   def translations
     return [] unless found?
     @translations ||= ayah.translations.where(resource_content_id: translation_ids).includes(:language, :foot_notes).to_a

--- a/app/views/ayah/_ayah_text.html.erb
+++ b/app/views/ayah/_ayah_text.html.erb
@@ -4,10 +4,10 @@
     font_class = get_quran_script_font_family(script, @ayah) || 'qpc-hafs'
   %>
 
-  <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-script-selector">
-    <div class="tw-flex tw-items-center tw-gap-2">
-      <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs"><%= @presenter.script_label %></span>
-    </div>
+   <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-script-selector">
+     <div class="tw-flex tw-items-center tw-gap-2">
+       <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs"><%= @presenter.script_label %></span>
+     </div>
 
     <button type="button"
             class="tw-px-3 tw-py-1.5 tw-bg-white tw-text-gray-900 tw-rounded tw-text-sm tw-border tw-border-gray-200 hover:tw-bg-gray-50"

--- a/app/views/ayah/_recitation.html.erb
+++ b/app/views/ayah/_recitation.html.erb
@@ -1,11 +1,11 @@
 <%= turbo_frame_tag :ayah_recitation do %>
-  <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-recitation-selector">
-    <div class="tw-flex tw-flex-wrap tw-gap-2">
-      <% rc = @presenter.recitation_resource %>
-      <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs">
-        <%= rc&.name.presence || "Recitation ##{@presenter.recitation_resource_id}" %>
-      </span>
-    </div>
+   <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-recitation-selector">
+     <div class="tw-flex tw-flex-wrap tw-gap-2">
+       <% rc = @presenter.recitation_resource %>
+       <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs">
+         <%= rc&.name.presence || "Recitation ##{@presenter.recitation_resource_id}" %>
+       </span>
+     </div>
 
     <button type="button"
             class="tw-px-3 tw-py-1.5 tw-bg-white tw-text-gray-900 tw-rounded tw-text-sm tw-border tw-border-gray-200 hover:tw-bg-gray-50"

--- a/app/views/ayah/_tafsirs.html.erb
+++ b/app/views/ayah/_tafsirs.html.erb
@@ -3,15 +3,12 @@
     <%= @ayah.text_qpc_hafs %>
   </div>
 
-  <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-tafsir-selector">
-    <div class="tw-flex tw-flex-wrap tw-gap-2">
-      <% @presenter.tafsir_ids.each do |rid| %>
-        <% rc = @presenter.tafsir_resources_by_id[rid] %>
-        <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs">
-          <%= rc&.name.presence || "Tafsir ##{rid}" %>
-        </span>
-      <% end %>
-    </div>
+   <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-tafsir-selector">
+     <div class="tw-flex tw-flex-wrap tw-gap-2">
+       <span class="tw-inline-flex tw-items-center tw-px-3 tw-py-1 tw-rounded tw-bg-blue-100 tw-text-blue-800 tw-text-sm tw-font-medium">
+         <%= @presenter.tafsir_ids.size %> tafsir<%= 's' if @presenter.tafsir_ids.size != 1 %> selected
+       </span>
+     </div>
 
     <button type="button"
             class="tw-px-3 tw-py-1.5 tw-bg-white tw-text-gray-900 tw-rounded tw-text-sm tw-border tw-border-gray-200 hover:tw-bg-gray-50"

--- a/app/views/ayah/_translations.html.erb
+++ b/app/views/ayah/_translations.html.erb
@@ -5,12 +5,9 @@
 
   <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-translation-selector">
     <div class="tw-flex tw-flex-wrap tw-gap-2">
-      <% @presenter.translation_ids.each do |rid| %>
-        <% rc = @presenter.translation_resources_by_id[rid] %>
-        <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs">
-          <%= rc&.name.presence || "Translation ##{rid}" %>
-        </span>
-      <% end %>
+      <span class="tw-inline-flex tw-items-center tw-px-3 tw-py-1 tw-rounded tw-bg-blue-100 tw-text-blue-800 tw-text-sm tw-font-medium">
+        <%= @presenter.translation_ids.size %> translation<%= 's' if @presenter.translation_ids.size != 1 %> selected
+      </span>
     </div>
 
     <button type="button"
@@ -27,14 +24,34 @@
           <i class="fa fa-times"></i>
         </button>
       </div>
+      <div class="tw-p-4 tw-border-b tw-border-gray-200">
+        <input type="text"
+               placeholder="Search translations..."
+               class="tw-w-full tw-px-3 tw-py-2 tw-border tw-border-gray-300 tw-rounded-md tw-text-sm tw-focus:outline-none tw-focus:ring-2 tw-focus:ring-blue-500 tw-focus:border-blue-500"
+               data-ayah-translation-selector-target="search"
+               data-action="input->ayah-translation-selector#search">
+      </div>
       <div class="tw-p-4 tw-overflow-y-auto tw-flex-1">
         <%= form_with url: ayah_translations_path(@ayah.verse_key), method: :get, local: true, data: { turbo_frame: :ayah_translations }, html: { data: { ayah_translation_selector_target: "form" } } do %>
-          <div class="tw-space-y-2">
-            <% @presenter.translation_resources.each do |rc| %>
-              <label class="tw-flex tw-items-start tw-gap-2 tw-text-sm tw-text-gray-800">
-                <%= check_box_tag "translation_ids[]", rc.id, @presenter.translation_ids.include?(rc.id), class: "tw-mt-1", data: { action: "change->ayah-translation-selector#change" } %>
-                <span><%= rc.name %></span>
-              </label>
+          <div class="tw-space-y-3" data-ayah-translation-selector-target="translationList">
+            <% @presenter.translation_resources_grouped_by_language.each do |language, resources| %>
+              <div class="translation-group" data-language="<%= language.downcase %>">
+                <button type="button"
+                        class="tw-flex tw-items-center tw-justify-between tw-w-full tw-px-3 tw-py-2 tw-text-left tw-bg-gray-50 tw-border tw-border-gray-200 tw-rounded-md tw-text-sm tw-font-medium tw-text-gray-900 hover:tw-bg-gray-100"
+                        data-action="click->ayah-translation-selector#toggleGroup"
+                        data-group="<%= language.downcase %>">
+                  <span><%= language %> (<%= resources.size %>)</span>
+                  <i class="fa fa-chevron-down tw-transition-transform tw-duration-200" data-ayah-translation-selector-target="chevron" data-group="<%= language.downcase %>"></i>
+                </button>
+                <div class="tw-mt-2 tw-space-y-2 tw-hidden" data-ayah-translation-selector-target="groupContent" data-group="<%= language.downcase %>">
+                  <% resources.each do |rc| %>
+                    <label class="tw-flex tw-items-start tw-gap-2 tw-text-sm tw-text-gray-800 translation-item" data-name="<%= rc.name.downcase %>">
+                      <%= check_box_tag "translation_ids[]", rc.id, @presenter.translation_ids.include?(rc.id), class: "tw-mt-1", data: { action: "change->ayah-translation-selector#change" } %>
+                      <span><%= rc.name %></span>
+                    </label>
+                  <% end %>
+                </div>
+              </div>
             <% end %>
           </div>
         <% end %>

--- a/app/views/ayah/_transliteration.html.erb
+++ b/app/views/ayah/_transliteration.html.erb
@@ -3,13 +3,13 @@
     <%= @ayah.text_qpc_hafs %>
   </div>
 
-  <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-transliteration-selector">
-    <div class="tw-flex tw-flex-wrap tw-gap-2">
-      <% rc = @presenter.transliteration_resources_by_id[@presenter.transliteration_id] %>
-      <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs">
-        <%= rc&.name.presence || "Transliteration ##{@presenter.transliteration_id}" %>
-      </span>
-    </div>
+   <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-transliteration-selector">
+     <div class="tw-flex tw-flex-wrap tw-gap-2">
+       <% rc = @presenter.transliteration_resources_by_id[@presenter.transliteration_id] %>
+       <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-1 tw-rounded tw-bg-gray-100 tw-text-gray-700 tw-text-xs">
+         <%= rc&.name.presence || "Transliteration ##{@presenter.transliteration_id}" %>
+       </span>
+     </div>
 
     <button type="button"
             class="tw-px-3 tw-py-1.5 tw-bg-white tw-text-gray-900 tw-rounded tw-text-sm tw-border tw-border-gray-200 hover:tw-bg-gray-50"

--- a/app/views/ayah/_words.html.erb
+++ b/app/views/ayah/_words.html.erb
@@ -1,8 +1,8 @@
 <%= turbo_frame_tag :ayah_words do %>
-  <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-word-translation-selector">
-    <div class="tw-text-sm tw-text-gray-700">
-      Word by word translation
-    </div>
+   <div class="tw-flex tw-items-start tw-justify-between tw-gap-4 tw-flex-wrap" data-controller="ayah-word-translation-selector">
+     <div class="tw-text-sm tw-text-gray-700">
+       Word by word translation
+     </div>
 
     <button type="button"
             class="tw-px-3 tw-py-1.5 tw-bg-white tw-text-gray-900 tw-rounded tw-text-sm tw-border tw-border-gray-200 hover:tw-bg-gray-50"


### PR DESCRIPTION
- Add search functionality to translation selector with language-based filtering
- Implement collapsible language groups in translation modal
- Fix dropdown collapse issue during multi-selection
- Standardize display logic: counts for multi-selection (translations/tafsirs), names for single-selection
- Improve UX consistency across all modal tabs