### PR TITLE
Horizontally center aya text within the mushaf page.

### DIFF
--- a/app/assets/stylesheets/shared/mushaf_page.scss
+++ b/app/assets/stylesheets/shared/mushaf_page.scss
@@ -157,6 +157,7 @@
     line-height: 1.85;
     text-align: center;
     display: flex;
+    justify-content: center;
     align-content: center;
     margin: auto;
   }


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1920" height="2099" alt="image" src="https://github.com/user-attachments/assets/0ed1b53a-65a4-4a28-ba56-2665127259dc" /> | <img width="1920" height="867" alt="image" src="https://github.com/user-attachments/assets/be44218d-7757-40e1-813d-806925b944b5" /> | 