### PR TITLE
Refactor ayah preview and phrase verse components for improved styling and structure

### DIFF
--- a/app/views/morphology_phrases/_ayah_preview.html.erb
+++ b/app/views/morphology_phrases/_ayah_preview.html.erb
@@ -24,41 +24,41 @@
   end
 %>
 
-<div class="page-section">
-  <div class="tw-flex flex-column tw-items-end">
-    <div class="badge tw-bg-green-500">
+<div class="tw-space-y-6">
+  <div class="tw-flex tw-flex-col tw-items-end">
+    <span class="tw-inline-flex tw-items-center tw-px-2.5 tw-py-0.5 tw-rounded tw-text-xs tw-font-medium tw-bg-green-600 tw-text-white">
       <%= verse.verse_key %>
-    </div>
-
-    <div class="quran-text qpc-hafs tw-flex flex-wrap">
+    </span>
+    <div class="quran-text qpc-hafs tw-flex tw-flex-wrap tw-gap-x-1 tw-mt-3 tw-text-2xl tw-leading-relaxed tw-text-right tw-justify-end">
       <% phrase_groups.each do |key, group| %>
         <% if key.is_a?(Morphology::Phrase) %>
           <%
             title = key.phrase_verses.approved.map &:text
             title = title.join("<br/>").html_safe
           %>
-          <div title="(<%= key.id %>: <%= key.source_verse.verse_key %>)<%= key.text_qpc_hafs %> <span class='badge badge-info'><%= key.occurrence %></span> <%= title %>"
-               class="mx-1 phrase tw-inline-flex"
-               data-controller="tooltip"
-               style="color: <%= key.get_color %>">
+          <span title="(<%= key.id %>: <%= key.source_verse.verse_key %>)<%= key.text_qpc_hafs %> <span class='tw-bg-blue-100 tw-text-blue-800 tw-px-1 tw-rounded tw-text-xs'><%= key.occurrence %></span> <%= title %>"
+                class="phrase tw-inline-flex tw-mr-1"
+                data-controller="tooltip"
+                style="color: <%= key.get_color %>">
             <% group.each do |w| %>
               <span><%= w.text_qpc_hafs %></span>
             <% end %>
-          </div>
+          </span>
         <% else %>
-           <span>
+          <span class="tw-text-gray-900">
             <%= group.text_qpc_hafs %>
-           </span>
+          </span>
         <% end %>
       <% end %>
     </div>
   </div>
 
-  <div class="tw-flex flex-column tw-items-end">
-    <span class="badge tw-bg-green-500 tw-mt-3">
-      Phrases
-    </span>
-
-    <%= render partial: 'phrase_verse', collection: ayah_phrases.sort_by { |s| -s.score }, as: :phrase_verse %>
+  <div class="tw-border-t tw-border-gray-200 tw-pt-6">
+    <h3 class="tw-text-lg tw-font-semibold tw-text-gray-800 tw-mb-4 tw-flex tw-items-center tw-gap-2">
+      <span class="tw-inline-flex tw-items-center tw-px-2.5 tw-py-0.5 tw-rounded tw-text-xs tw-font-medium tw-bg-green-600 tw-text-white">Phrases</span>
+    </h3>
+    <div class="tw-space-y-3">
+      <%= render partial: 'phrase_verse', collection: ayah_phrases.sort_by { |s| -s.score }, as: :phrase_verse %>
+    </div>
   </div>
 </div>

--- a/app/views/morphology_phrases/_phrase_verse.html.erb
+++ b/app/views/morphology_phrases/_phrase_verse.html.erb
@@ -1,44 +1,34 @@
 <%
   phrase = phrase_verse.phrase
-
   approved_count = phrase.phrase_verses.approved.size
   not_approved_count = phrase.phrase_verses.not_approved.size
 %>
 
-<div id="<%= dom_id phrase_verse %>" class="tw-flex tw-items-center" style="flex-direction: row-reverse;">
-  <div class="tw-flex">
-    <%= link_to "/cms/morphology_phrases/#{phrase.id}", target: :_blank, class: 'ms-2' do %>
-      <span style="display:inline-block;width: 20px; height: 20px; background: <%= phrase.get_color %>"></span>
-      <span class="<%= 'text-danger' if !phrase.approved? %>"><%= phrase.verses_count %>(<%= phrase.review_status %>
-        )</span>
+<div id="<%= dom_id phrase_verse %>" class="tw-flex tw-flex-row-reverse tw-items-center tw-gap-4 tw-p-3 tw-bg-gray-50 tw-rounded-lg tw-border tw-border-gray-200 hover:tw-bg-gray-100 tw-transition-colors">
+  <div class="tw-flex tw-items-center tw-gap-3 tw-flex-wrap">
+    <%= link_to "/cms/morphology_phrases/#{phrase.id}", target: :_blank, class: 'tw-flex tw-items-center tw-gap-2 tw-no-underline hover:tw-opacity-80' do %>
+      <span class="tw-inline-block tw-w-4 tw-h-4 tw-rounded-sm tw-flex-shrink-0" style="background: <%= phrase.get_color %>"></span>
+      <span class="tw-text-sm tw-font-medium <%= 'tw-text-red-600' if !phrase.approved? %>"><%= phrase.verses_count %> (<%= phrase.review_status %>)</span>
     <% end %>
-
     <% if @access %>
-      <div class="tw-ms-4">
-        <%= form_with model: phrase_verse, url: "/morphology_phrases/#{phrase_verse.id}", method: :put, html: { class: 'form-inline' } do |form| %>
-          <div class="tw-flex tw-my-2">
-            <div class="tw-me-2">
-              <small>p: <%= phrase.id %> s: <%= phrase_verse.score %></small>
-
-              <span class="badge tw-bg-green-500"
-                    type="button"
-                    data-controller="collapse" data-action="click->collapse#toggle"
-                    data-bs-target="#phrase-<%= phrase.id %>-related"
-                    aria-expanded="false"
-                    aria-controls="phrase-<%= phrase.id %>-related">
-            <%= approved_count %>
-          </span>
-              <span class="badge tw-bg-red-500"><%= not_approved_count %></span>
-            </div>
-            <%= form.button("<i class='fas fa-times'></i>".html_safe, name: 'disabled', type: :submit, title: 'Disable', class: "tw-mr-2 tw-px-3 tw-py-1.5 tw-text-xs tw-font-medium tw-rounded tw-transition-colors #{phrase_verse.phrase.approved? && phrase_verse.approved? ? 'tw-bg-transparent tw-text-red-600 tw-border tw-border-red-600 hover:tw-bg-red-600 hover:tw-text-white' : 'tw-bg-red-600 hover:tw-bg-red-700 tw-text-white'}", data: { controller: 'tooltip' }) %>
-            <%= form.button("<i class='fas fa-check'></i>".html_safe, name: 'approved', type: :submit, title: 'Approve', class: "tw-px-3 tw-py-1.5 tw-text-sm tw-font-medium tw-rounded tw-transition-colors #{phrase_verse.phrase.approved? && phrase_verse.approved? ? 'tw-bg-green-600 hover:tw-bg-green-700 tw-text-white' : 'tw-border tw-border-green-600 tw-text-green-600 hover:tw-bg-green-600 hover:tw-text-white'}", data: { controller: 'tooltip' }) %>
-          </div>
-        <% end %>
-      </div>
+      <%= form_with model: phrase_verse, url: "/morphology_phrases/#{phrase_verse.id}", method: :put do |form| %>
+        <div class="tw-flex tw-items-center tw-gap-2 tw-flex-wrap">
+          <span class="tw-text-xs tw-text-gray-500">p: <%= phrase.id %> s: <%= phrase_verse.score %></span>
+          <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-0.5 tw-rounded tw-text-xs tw-font-medium tw-bg-green-100 tw-text-green-800"
+                type="button"
+                data-controller="collapse"
+                data-action="click->collapse#toggle"
+                data-bs-target="#phrase-<%= phrase.id %>-related"
+                aria-expanded="false"
+                aria-controls="phrase-<%= phrase.id %>-related"><%= approved_count %></span>
+          <span class="tw-inline-flex tw-items-center tw-px-2 tw-py-0.5 tw-rounded tw-text-xs tw-font-medium tw-bg-red-100 tw-text-red-800"><%= not_approved_count %></span>
+          <%= form.button("<i class='fas fa-times'></i>".html_safe, name: 'disabled', type: :submit, title: 'Disable', class: "tw-px-2.5 tw-py-1 tw-text-xs tw-font-medium tw-rounded tw-transition-colors #{phrase_verse.phrase.approved? && phrase_verse.approved? ? 'tw-bg-transparent tw-text-red-600 tw-border tw-border-red-300 hover:tw-bg-red-50' : 'tw-bg-red-600 hover:tw-bg-red-700 tw-text-white'}", data: { controller: 'tooltip', tooltip_placement_value: 'top' }) %>
+          <%= form.button("<i class='fas fa-check'></i>".html_safe, name: 'approved', type: :submit, title: 'Approve', class: "tw-px-2.5 tw-py-1 tw-text-xs tw-font-medium tw-rounded tw-transition-colors #{phrase_verse.phrase.approved? && phrase_verse.approved? ? 'tw-bg-green-600 hover:tw-bg-green-700 tw-text-white' : 'tw-border tw-border-green-600 tw-text-green-600 hover:tw-bg-green-50'}", data: { controller: 'tooltip', tooltip_placement_value: 'top' }) %>
+        </div>
+      <% end %>
     <% end %>
   </div>
-
-  <div class="quran-text qpc-hafs">
+  <div class="quran-text qpc-hafs tw-text-xl tw-font-medium" style="<%= phrase.get_color.present? ? "color: #{phrase.get_color}" : 'color: #111827' %>">
     <%= phrase.text_qpc_hafs %>
   </div>
 </div>

--- a/app/views/morphology_phrases/show.html.erb
+++ b/app/views/morphology_phrases/show.html.erb
@@ -18,11 +18,13 @@
              key: 'ayah_mutashabihat',
              actions: actions
   %>
-  <div class="page-wrapper tw-container tw-max-w-7xl tw-mx-auto tw-px-4">
-    <%= render 'ayah_preview', mapping: {
+  <div class="page-wrapper tw-container tw-max-w-7xl tw-mx-auto tw-px-4 tw-mt-4 tw-relative tw-z-10">
+    <div class="tw-bg-white tw-rounded-xl tw-shadow-sm tw-border tw-border-gray-200 tw-p-6 tw-mb-6">
+      <%= render 'ayah_preview', mapping: {
       verse: @verse,
       phrase_verses: @verse.verse_phrases,
     } %>
+    </div>
   </div>
 <% else %>
   <%= render 'suggestions' %>


### PR DESCRIPTION
- Updated the layout of the ayah preview to enhance visual hierarchy and spacing.

| Before | After |
|--------|--------|
| <img width="1920" height="867" alt="image" src="https://github.com/user-attachments/assets/de5b396f-6af8-4b3e-9d84-249b96c5a587" /> | <img width="1920" height="1154" alt="image" src="https://github.com/user-attachments/assets/9e6cfa46-896f-4245-849e-a7dddc124731" /> | 