### PR TITLE
Fix surah segments endpoint to accept chapter query param

### DIFF
--- a/app/presenters/v1/audio/segment_presenter.rb
+++ b/app/presenters/v1/audio/segment_presenter.rb
@@ -51,7 +51,7 @@ module V1
       end
 
       def chapter_id
-        params[:surah]
+        params[:chapter] || params[:surah]
       end
 
       def ayah


### PR DESCRIPTION
`Fix:`

- Accept chapter as the primary param
- Fallback to surah for backward compatibility

`Result:`
The endpoint now correctly returns 200 for valid requests instead of 500.