### PR TITLE
fix: add esbuild target for older browser compatibility

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -64,6 +64,7 @@ const config = {
     'global': 'globalThis',
   },
   inject: [],
+  target: ['es2019'],
 }
 
 async function buildAndReload() {


### PR DESCRIPTION
## Summary
- Adds `target: ['es2019']` to the esbuild config so modern syntax like optional chaining (`?.`) and nullish coalescing (`??`) gets transpiled automatically for browsers that don't support ES2020+
- This is a build-level fix — no source code changes needed, keeping the codebase clean and modern

Fixes #460

## Verified locally

**Before** (main branch) — optional chaining passes through raw:
```js
// app/assets/builds/application.js
const result = this.element.closest(".quiz-container")?.querySelector("#quiz-result");
```

**After** (this branch) — esbuild transpiles it:
```js
// app/assets/builds/application.js
const result = (_a = this.element.closest(".quiz-container")) == null ? void 0 : _a.querySelector("#quiz-result");
```

The 3 remaining `?.` in the build output are inside **string literals** from the Trix library (e.g. `proxyMethod("delegate?.getSelectionManager")`), not executable JS syntax.

## Test plan
- [x] `yarn build` completes without errors
- [x] Built JS output no longer contains executable `?.` or `??` operators
- [ ] Smoke test the app in an older browser or Safari to confirm no parser errors


🤲 May Allah accept this contribution