### PR TITLE
Enhance audio file display with chapter name in index view

### DIFF
--- a/app/views/surah_audio_files/index.html.erb
+++ b/app/views/surah_audio_files/index.html.erb
@@ -51,7 +51,9 @@
       <tbody>
       <% @audio_files.each do |file| %>
         <tr class="hover:tw-bg-gray-200 tw-border-b">
-          <th scope="row" class="tw-py-2 tw-pl-2"><%= file.chapter_id %></th>
+          <th scope="row" class="tw-py-2 tw-pl-2 tw-text-left">
+            <%= file.chapter_id %> - <%= file.chapter.name_simple %>
+          </th>
 
           <td class="tw-py-2">
             <% progress = [file.segment_progress, 100].min %>


### PR DESCRIPTION
Enhance audio file display by adding chapter name alongside chapter ID in the surah audio files index view.

| Before | After |
|--------|--------|
| <img width="1920" height="867" alt="image" src="https://github.com/user-attachments/assets/1ebb8aed-dac7-4d87-9f44-ae9da6100c03" /> | <img width="1920" height="867" alt="image" src="https://github.com/user-attachments/assets/929ef37f-22cf-4255-b89a-e0db4a721856" /> | 