### PR TITLE
Add FAQ permalink copy-to-clipboard with toast

### DIFF
--- a/app/javascript/controllers/copy_to_clipboard_controller.js
+++ b/app/javascript/controllers/copy_to_clipboard_controller.js
@@ -1,22 +1,56 @@
 import { Controller } from "@hotwired/stimulus";
 import copyToClipboard from "copy-to-clipboard";
+import toastr from "toastr";
+
+toastr.options = {
+  closeButton: true,
+  debug: false,
+  newestOnTop: true,
+  progressBar: true,
+  positionClass: "toast-top-right",
+  preventDuplicates: true,
+  onclick: null,
+  showDuration: 300,
+  hideDuration: 100,
+  timeOut: 5000,
+  extendedTimeOut: 0,
+  showEasing: "swing",
+  hideEasing: "linear",
+  showMethod: "fadeIn",
+  hideMethod: "fadeOut",
+  tapToDismiss: true
+};
 
 export default class extends Controller {
-  copy = () => {
+  copy = (event) => {
+    const isolate = this.element.dataset.stopPropagation !== undefined;
+
+    if (isolate) {
+      if (event.button !== 0) return;
+      if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return;
+      event.preventDefault();
+      event.stopPropagation();
+    }
+
     const text =
       this.element.dataset.text ||
       this.element.textContent.trim();
 
     copyToClipboard(text);
 
-    this.element.dispatchEvent(
-      new CustomEvent("tooltip:update", {
-        detail: {
-          text: "Copied",
-          temporary: true
-        }
-      })
-    );
+    const toastMessage = this.element.dataset.toastMessage;
+    if (toastMessage) {
+      toastr.success(toastMessage);
+    } else {
+      this.element.dispatchEvent(
+        new CustomEvent("tooltip:update", {
+          detail: {
+            text: "Copied",
+            temporary: true
+          }
+        })
+      );
+    }
   };
 
   connect() {

--- a/app/views/community/faq.html.erb
+++ b/app/views/community/faq.html.erb
@@ -19,7 +19,11 @@
         <div class="item tw-cursor-pointer" id="faq-<%= faq.id %>">
           <div class="tw-py-4 tw-flex question-wrapper tw-items-center tw-justify-between">
             <span class="tw-me-1">
-              <a href="#faq-<%= faq.id %>">🔗</a>
+              <a href="<%= faq_path(anchor: "faq-#{faq.id}") %>"
+                 data-controller="copy-to-clipboard"
+                 data-text="<%= faq_url(anchor: "faq-#{faq.id}") %>"
+                 data-stop-propagation
+                 data-toast-message="Link copied to clipboard">🔗</a>
             </span>
 
             <a href="#faq-<%= faq.id %>" class="question tw-flex-1">


### PR DESCRIPTION
- Enhance copy-to-clipboard functionality with toastr notifications
- Integrate toastr for user feedback upon copying links to clipboard.
- Update copy method to handle event propagation based on data attributes.
- Modify FAQ links to utilize the new clipboard functionality with custom toast messages.