### PR TITLE
Responsive mushaf page navigation for small screens

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -150,6 +150,10 @@
     @apply tw-py-3 tw-px-8 tw-text-lg;
   }
 
+  .btn-header-action {
+    @apply tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3;
+  }
+
   .btn-cta {
     @apply tw-bg-gray-900 tw-text-white tw-rounded-full tw-text-sm tw-font-semibold tw-border-gray-900 hover:tw-bg-gray-800 hover:tw-text-white tw-transition-colors tw-px-8 tw-py-3;
   }

--- a/app/views/morphology_phrases/index.html.erb
+++ b/app/views/morphology_phrases/index.html.erb
@@ -3,7 +3,7 @@
 
   if @access
     actions << link_to('New Phrase', new_morphology_phrase_path, class: 'tw-h-10 btn btn-success tw-inline-flex tw-items-center', data: { controller: 'ajax-modal', url: new_morphology_phrase_path(modal: true) })
-    actions << link_to('View bookmarks', '#_', class: 'tw-h-10 btn btn-dark tw-inline-flex tw-items-center', data: { controller: 'phrase-ayah-bookmark' })
+    actions << link_to('View bookmarks', '#_', class: 'btn btn-dark btn-header-action', data: { controller: 'phrase-ayah-bookmark' })
   end
 
   if params[:proofread]

--- a/app/views/mushaf_layouts/edit.html.erb
+++ b/app/views/mushaf_layouts/edit.html.erb
@@ -32,12 +32,19 @@
       </ul>
     </div>
   }
-
-  actions << link_to('Previous Page', edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark', data: turbo_mushaf_page_options)
-  actions << link_to('Next page', edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark', data: turbo_mushaf_page_options)
-
-  actions << link_to('Back to mushaf list', mushaf_layouts_path, class: 'tw-h-10 btn btn-info tw-flex tw-items-center')
 %>
+<% actions << link_to(edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Previous page' }) do %>
+  <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg></span>
+  <span class="tw-hidden md:tw-inline">Previous Page</span>
+<% end %>
+<% actions << link_to(edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Next page' }) do %>
+  <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg></span>
+  <span class="tw-hidden md:tw-inline">Next page</span>
+<% end %>
+<% actions << link_to(mushaf_layouts_path, class: 'tw-h-10 btn btn-info tw-inline-flex tw-items-center tw-justify-center tw-shrink-0 tw-px-2 md:tw-px-3', aria: { label: 'Back to mushaf list' }) do %>
+  <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"></path></svg></span>
+  <span class="tw-hidden md:tw-inline">Back to mushaf list</span>
+<% end %>
 
 <%= turbo_frame_tag :page do %>
   <%= render 'tools/header',

--- a/app/views/mushaf_layouts/edit.html.erb
+++ b/app/views/mushaf_layouts/edit.html.erb
@@ -33,15 +33,15 @@
     </div>
   }
 %>
-<% actions << link_to(edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Previous page' }) do %>
+<% actions << link_to(edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark btn-header-action', data: turbo_mushaf_page_options, aria: { label: 'Previous page' }) do %>
   <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg></span>
   <span class="tw-hidden md:tw-inline">Previous Page</span>
 <% end %>
-<% actions << link_to(edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Next page' }) do %>
+<% actions << link_to(edit_mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark btn-header-action', data: turbo_mushaf_page_options, aria: { label: 'Next page' }) do %>
   <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg></span>
   <span class="tw-hidden md:tw-inline">Next page</span>
 <% end %>
-<% actions << link_to(mushaf_layouts_path, class: 'tw-h-10 btn btn-info tw-inline-flex tw-items-center tw-justify-center tw-shrink-0 tw-px-2 md:tw-px-3', aria: { label: 'Back to mushaf list' }) do %>
+<% actions << link_to(mushaf_layouts_path, class: 'btn btn-info btn-header-action', aria: { label: 'Back to mushaf list' }) do %>
   <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"></path></svg></span>
   <span class="tw-hidden md:tw-inline">Back to mushaf list</span>
 <% end %>

--- a/app/views/mushaf_layouts/show_page.html.erb
+++ b/app/views/mushaf_layouts/show_page.html.erb
@@ -39,12 +39,19 @@
       </ul>
     </div>
   }
-
-  actions << link_to('Previous Page', mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark', data: turbo_mushaf_page_options)
-  actions << link_to('Next page', mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark', data: turbo_mushaf_page_options)
-
-  actions << link_to('Back to all pages', mushaf_layout_path(@mushaf.id), class: 'btn btn-info', data: {turbo_frame: '_top'})
 %>
+<% actions << link_to(mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Previous page' }) do %>
+  <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg></span>
+  <span class="tw-hidden md:tw-inline">Previous Page</span>
+<% end %>
+<% actions << link_to(mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Next page' }) do %>
+  <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg></span>
+  <span class="tw-hidden md:tw-inline">Next page</span>
+<% end %>
+<% actions << link_to(mushaf_layout_path(@mushaf.id), class: 'btn btn-info tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: { turbo_frame: '_top' }, aria: { label: 'Back to all pages' }) do %>
+  <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"></path></svg></span>
+  <span class="tw-hidden md:tw-inline">Back to all pages</span>
+<% end %>
 
 <%= turbo_frame_tag :page do %>
   <%= render 'tools/header',

--- a/app/views/mushaf_layouts/show_page.html.erb
+++ b/app/views/mushaf_layouts/show_page.html.erb
@@ -40,15 +40,15 @@
     </div>
   }
 %>
-<% actions << link_to(mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Previous page' }) do %>
+<% actions << link_to(mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number - 1, view_type: params[:view_type]), class: 'btn btn-dark btn-header-action', data: turbo_mushaf_page_options, aria: { label: 'Previous page' }) do %>
   <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path></svg></span>
   <span class="tw-hidden md:tw-inline">Previous Page</span>
 <% end %>
-<% actions << link_to(mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: turbo_mushaf_page_options, aria: { label: 'Next page' }) do %>
+<% actions << link_to(mushaf_layout_path(@mushaf.id, compare: @compared_mushaf&.id, page_number: page_number + 1, view_type: params[:view_type]), class: 'btn btn-dark btn-header-action', data: turbo_mushaf_page_options, aria: { label: 'Next page' }) do %>
   <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg></span>
   <span class="tw-hidden md:tw-inline">Next page</span>
 <% end %>
-<% actions << link_to(mushaf_layout_path(@mushaf.id), class: 'btn btn-info tw-inline-flex tw-items-center tw-justify-center tw-h-10 tw-shrink-0 tw-px-2 md:tw-px-3', data: { turbo_frame: '_top' }, aria: { label: 'Back to all pages' }) do %>
+<% actions << link_to(mushaf_layout_path(@mushaf.id), class: 'btn btn-info btn-header-action', data: { turbo_frame: '_top' }, aria: { label: 'Back to all pages' }) do %>
   <span class="tw-inline-flex md:tw-hidden" aria-hidden="true"><svg class="tw-w-5 tw-h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"></path></svg></span>
   <span class="tw-hidden md:tw-inline">Back to all pages</span>
 <% end %>


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/7973d607-828d-4289-ac3e-ef4fc046409b" />| <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/2871be84-3a6d-4228-be2a-d59d7cb669f4" /> | 

- Refactor navigation buttons in Mushaf layout views for improved accessibility and styling
- Update 'Previous Page', 'Next Page', and 'Back to mushaf list' links in edit and show_page views to include accessible aria labels and enhanced styling with Tailwind CSS classes.
- Ensure consistent button design across both views for better user experience.