### PR TITLE
docs: add resource-guides-index referenced from README

### DIFF
--- a/docs/resource-guides-index.md
+++ b/docs/resource-guides-index.md
@@ -1,0 +1,47 @@
+# Resource Guides Index
+
+Direct entry point to every QUL resource guide. Each entry links to the resource overview page and its canonical end-to-end tutorial.
+
+If you are choosing a category for the first time, see [datasets.md](datasets.md) for a higher-level overview. If you prefer a step-by-step path, see [tutorials.md](tutorials.md).
+
+## Quran Text and Script
+
+- Quran Script: [resource-quran-script.md](resource-quran-script.md) — tutorial: [tutorial-quran-script-end-to-end.md](tutorial-quran-script-end-to-end.md)
+- Quran Metadata: [resource-quran-metadata.md](resource-quran-metadata.md) — tutorial: [tutorial-quran-metadata-end-to-end.md](tutorial-quran-metadata-end-to-end.md)
+- Surah Information: [resource-surah-information.md](resource-surah-information.md) — tutorial: [tutorial-surah-information-end-to-end.md](tutorial-surah-information-end-to-end.md)
+- Mushaf Layouts: [resource-mushaf-layouts.md](resource-mushaf-layouts.md) — tutorial: [tutorial-mushaf-layout-end-to-end.md](tutorial-mushaf-layout-end-to-end.md)
+- Quran Fonts: [resource-fonts.md](resource-fonts.md) — tutorial: [tutorial-font-end-to-end.md](tutorial-font-end-to-end.md)
+
+## Translations, Tafsirs, Transliteration
+
+- Translations: [resource-translations.md](resource-translations.md) — tutorial: [tutorial-translation-end-to-end.md](tutorial-translation-end-to-end.md)
+- Tafsirs: [resource-tafsirs.md](resource-tafsirs.md) — tutorial: [tutorial-tafsir-end-to-end.md](tutorial-tafsir-end-to-end.md)
+- Transliteration: [resource-transliteration.md](resource-transliteration.md) — tutorial: [tutorial-transliteration-end-to-end.md](tutorial-transliteration-end-to-end.md)
+
+## Topics, Themes, Similarities
+
+- Ayah Topics: [resource-ayah-topics.md](resource-ayah-topics.md) — tutorial: [tutorial-ayah-topics-end-to-end.md](tutorial-ayah-topics-end-to-end.md)
+- Ayah Theme: [resource-ayah-theme.md](resource-ayah-theme.md) — tutorial: [tutorial-ayah-theme-end-to-end.md](tutorial-ayah-theme-end-to-end.md)
+- Similar Ayah: [resource-similar-ayah.md](resource-similar-ayah.md) — tutorial: [tutorial-similar-ayah-end-to-end.md](tutorial-similar-ayah-end-to-end.md)
+- Mutashabihat: [resource-mutashabihat.md](resource-mutashabihat.md) — tutorial: [tutorial-mutashabihat-end-to-end.md](tutorial-mutashabihat-end-to-end.md)
+- Topics and Concepts (legacy umbrella): [resource-topics-and-concepts.md](resource-topics-and-concepts.md)
+
+## Audio and Recitations
+
+- Recitations: [resource-recitations.md](resource-recitations.md) — tutorial: [tutorial-recitation-end-to-end.md](tutorial-recitation-end-to-end.md)
+
+## Linguistic Data
+
+- Morphology: [resource-morphology.md](resource-morphology.md) — tutorial: [tutorial-morphology-end-to-end.md](tutorial-morphology-end-to-end.md)
+
+## Related
+
+- Datasets overview: [datasets.md](datasets.md)
+- Tutorials index: [tutorials.md](tutorials.md)
+- Data model: [data-model.md](data-model.md)
+- Resource guide template: [resource-guide-template.md](resource-guide-template.md)
+- Resource-to-tutorial mapping: [resource-tutorial-map.md](resource-tutorial-map.md)
+
+## Download Resources
+
+Browse all datasets in the website resources directory: [https://qul.tarteel.ai/resources](https://qul.tarteel.ai/resources)


### PR DESCRIPTION
- README.md links to docs/resource-guides-index.md (line 50), which did not exist in the repo
- Added the file as a categorized index of all docs/resource-*.md pages, each entry pointing to its canonical end-to-end tutorial
- Five sections: Quran Text and Script; Translations, Tafsirs, Transliteration; Topics, Themes, Similarities; Audio and Recitations; Linguistic Data
- All 36 internal markdown links validated against existing files in docs/
- Pure docs addition; no code, tests, or migrations
