### PR TITLE
fix: guard findVerseSegment against undefined verseSegments

### DIFF
--- a/app/javascript/segments/helper/findSegment.js
+++ b/app/javascript/segments/helper/findSegment.js
@@ -16,6 +16,11 @@ const findSegment = (timestamp, segments, currentVerse, chapter, currentWord, ve
 };
 
 const findVerseSegment = (timestamp, verseSegments, currentWord) => {
+  // Guard against undefined verseSegments parameter (e.g. segments[currentVerseKey] miss)
+  if (!verseSegments) {
+    return {};
+  }
+
   const segments = verseSegments.segments || [];
   let target = {};
 


### PR DESCRIPTION
Completes the defensive guards added to `findSegment` and `findSurahVerseSegment` in #557 by also guarding `findVerseSegment`.

**Reachable via the `audioType == 'ayah'` path in `SET_TIMESTAMP`:**
```js
// app/javascript/segments/store/index.js (around L631-L638)
if (audioType == 'ayah') {
  const { word } = findVerseSegment(
    time,
    segments[currentVerseKey],   // can be undefined for a stale or out-of-range key
    currentWord
  );
  ...
}
```

If `segments[currentVerseKey]` is undefined here, the next line in `findVerseSegment` (`verseSegments.segments || []`) throws the same `Cannot read properties of undefined (reading 'segments')` reported in #459.

The added guard returns `{}` — identical to what the binary search returns when no segment matches the timestamp — so call sites that destructure `.word` still receive `undefined` and behave the same as the existing no-match path.

Related: #459, #557.
