### PR TITLE
chore: bump rubocop TargetRailsVersion to 8.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 3.3
-  TargetRailsVersion: 7.0
+  TargetRailsVersion: 8.0
   NewCops: enable
   SuggestExtensions: false
   Exclude:


### PR DESCRIPTION
`.rubocop.yml` pins `TargetRailsVersion: 7.0`, but `Gemfile` is now on `rails (~> 8.0.0)` (resolved `rails (8.0.3)` in `Gemfile.lock`).

```yaml
AllCops:
  TargetRubyVersion: 3.3
  TargetRailsVersion: 8.0   # was 7.0
```

Effect of the drift: rubocop-rails cops gated on `TargetRailsVersion >= 7.1` (e.g. `Rails/EagerEvaluationLogMessage`, `Rails/I18nLocaleAssignment`) and Rails 8-aware cops do not fire, so the lint output silently misses Rails 8 deprecations and recommendations.

Single-line config change; no Ruby code touched.
