### PR TITLE
chore: bump bootsnap to 1.24.3 for Ruby 3.3 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     benchmark-ips (2.13.0)
     bigdecimal (4.0.1)
     bindex (0.8.1)
-    bootsnap (1.12.0)
+    bootsnap (1.24.3)
       msgpack (~> 1.2)
     builder (3.3.0)
     cancancan (3.4.0)


### PR DESCRIPTION
**Fixes `bundle install` failing on Ruby 3.3.3 (the version pinned by `.ruby-version`).**

The lockfile currently pins `bootsnap (1.12.0)` (released April 2022). That release predates Ruby 3.3 support and its C extension fails to compile against the Ruby 3.3 headers with a recent GCC:

```
ruby-3.3.0/ruby/internal/scan_args.h:390:43: error: unknown type name 'bool'
ruby-3.3.0/ruby/internal/intern/load.h:234:25: error: unknown type name 'bool'
...
make: *** [Makefile:248: bootsnap.o] Error 1
```

(Native `bool` is reachable from Ruby 3.3 internal headers but bootsnap 1.12.0's prelude doesn't `#include <stdbool.h>`. This was fixed in later bootsnap releases — see [Shopify/bootsnap#479](https://github.com/Shopify/bootsnap/pull/479).)

### Change

`bundle update bootsnap --conservative` — single-line lockfile bump:

```diff
-    bootsnap (1.12.0)
+    bootsnap (1.24.3)
       msgpack (~> 1.2)
```

The `Gemfile` constraint is `bootsnap (>= 1.4.4)`, so 1.24.3 satisfies it and `--conservative` left every other gem at its existing pin. Only `Gemfile.lock` changes; no `Gemfile` edit, no other gems bumped.

### Verification

- Before: `bundle install` aborts on bootsnap (build log above).
- After: `bundle install` → `Bundle complete! 78 Gemfile dependencies, 233 gems now installed.` on a clean Ubuntu 24.04 / Ruby 3.3.3 / GCC 14 box.

### Notes

- `.ruby-version` pins `3.3.3`, so any contributor following the documented setup hits this. Unblocks onboarding without touching application code.
- `Gemfile.lock`'s `RUBY VERSION` line still reads `3.3.5p100` — that's informational only and unrelated to this fix; left untouched to keep the diff minimal.
