### PR TITLE
docs: document database env vars in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,18 @@
+# Database connection (development and test)
+# These match the defaults baked into docker-compose.yml (postgres:14 with POSTGRES_PASSWORD=password)
+DB_HOST: "localhost"
+DB_PORT: "5432"
+DB_USERNAME: "postgres"
+DB_PASSWORD: "password"
+
+# Optional: separate Quran API DB connection (otherwise the dev connection above is reused)
+# QURAN_API_DB_NAME: "quran_dev"
+# QURAN_API_DB_HOST: "localhost"
+# QURAN_API_DB_PORT: "5432"
+# QURAN_API_DB_USERNAME: "postgres"
+# QURAN_API_DB_PASSWORD: "password"
+
+# Object storage (S3-compatible) — only required for export-to-CDN flows
 QUL_STORAGE_ACCESS_KEY: "aws access key"
 QUL_STORAGE_ACCESS_KEY_SECRET: "aws key secret"
 QUL_STORAGE_BUCKET: "bucket name"


### PR DESCRIPTION
`.env.sample` only lists the six S3-storage variables. The development setup also reads four database variables that aren't documented anywhere in the repo:

```yaml
# config/database.yml
development:
  adapter: postgresql
  database: quran_community_tarteel
  host: <%= ENV['DB_HOST'] %>
  port: <%= ENV.fetch('DB_PORT', '5432') %>
  username: <%= ENV['DB_USERNAME'] %>
  password: <%= ENV['DB_PASSWORD'] %>
```

A new contributor cloning the repo has no way to know:
- which env keys to set
- what the matching values are for the bundled `docker-compose.yml` (`POSTGRES_USER=postgres`, `POSTGRES_PASSWORD=password`, port 5432)
- that a separate Quran API DB connection (`QURAN_API_DB_*`) is also supported

### Change
- Added `DB_HOST`, `DB_PORT`, `DB_USERNAME`, `DB_PASSWORD` to `.env.sample` with values that match the defaults in `docker-compose.yml`.
- Added commented-out `QURAN_API_DB_*` block for the optional secondary connection (in case a contributor wants to point it at a different host).
- Grouped existing storage vars under a comment header and added a trailing newline.

The format follows the existing `KEY: "value"` style already used in the file (dotenv 3 parses it the same as `KEY=value`).

Pure docs: no code, no migrations.
