### PR TITLE
chore: remove duplicate assets:precompile in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,6 @@ RUN yarn install --frozen-lockfile
 
 # precompile assets
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 
 # pg_dump
 RUN apt-get install -y wget


### PR DESCRIPTION
`Dockerfile` runs `bin/rails assets:precompile` twice in a row at lines 171-172. The second invocation is a no-op (the assets are already on disk after the first run) but it still loads Rails, scans the asset tree, and produces the cached compile log a second time — adding ~30s to every image build.

```diff
 # precompile assets
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
```

No code changes, no behaviour change for the final image.
