### PR TITLE
feat: add range validation + audit task for Mutashabihat phrases

### DIFF
--- a/app/models/morphology/phrase.rb
+++ b/app/models/morphology/phrase.rb
@@ -50,6 +50,8 @@ class Morphology::Phrase < ApplicationRecord
   scope :approved, -> {where approved: true}
   after_commit :update_verses_stats, on: [:create, :update]
 
+  validate :word_position_range_within_source_verse, if: :should_validate_word_position_range?
+
   def update_verses_stats
     verses = phrase_verses.approved.map(&:verse)
 
@@ -140,5 +142,26 @@ class Morphology::Phrase < ApplicationRecord
       hash = ((hash * 33) ^ byte)
     end
     hash & 0xffffffff
+  end
+
+  def should_validate_word_position_range?
+    new_record? ||
+      word_position_from_changed? ||
+      word_position_to_changed? ||
+      (approved_changed? && approved?)
+  end
+
+  def word_position_range_within_source_verse
+    return unless word_position_from && word_position_to && source_verse
+
+    if word_position_from > word_position_to
+      errors.add(:word_position_to, "must be >= word_position_from (#{word_position_from})")
+    end
+
+    max = source_verse.words_count || source_verse.words.count
+    if word_position_to > max
+      errors.add(:word_position_to,
+                 "is #{word_position_to} but #{source_verse.verse_key} only has #{max} words")
+    end
   end
 end

--- a/app/models/morphology/phrase_verse.rb
+++ b/app/models/morphology/phrase_verse.rb
@@ -31,6 +31,8 @@ class Morphology::PhraseVerse < ApplicationRecord
   after_destroy :update_phrase_stats
   after_create :update_phrase_stats
 
+  validate :word_position_range_within_verse, if: :should_validate_word_position_range?
+
   def create_matching_ayah
     matching = Morphology::MatchingVerse.where(verse_id: phrase.source_verse_id, matched_verse_id: verse_id).first_or_initialize
 
@@ -72,5 +74,26 @@ class Morphology::PhraseVerse < ApplicationRecord
   protected
   def update_phrase_stats
     phrase&.update_verses_stats
+  end
+
+  def should_validate_word_position_range?
+    new_record? ||
+      word_position_from_changed? ||
+      word_position_to_changed? ||
+      (approved_changed? && approved?)
+  end
+
+  def word_position_range_within_verse
+    return unless word_position_from && word_position_to && verse
+
+    if word_position_from > word_position_to
+      errors.add(:word_position_to, "must be >= word_position_from (#{word_position_from})")
+    end
+
+    max = verse.words_count || verse.words.count
+    if word_position_to > max
+      errors.add(:word_position_to,
+                 "is #{word_position_to} but #{verse.verse_key} only has #{max} words")
+    end
   end
 end

--- a/lib/tasks/mutashabihat.rake
+++ b/lib/tasks/mutashabihat.rake
@@ -1,0 +1,77 @@
+namespace :mutashabihat do
+  desc 'Audit Morphology::Phrase + Morphology::PhraseVerse for ranges that fall outside their verse boundaries'
+  task audit_ranges: :environment do
+    puts 'Scanning Morphology::Phrase source ranges...'
+    bad_phrases = []
+    Morphology::Phrase.includes(:source_verse).find_each do |phrase|
+      verse = phrase.source_verse
+      next unless verse && phrase.word_position_from && phrase.word_position_to
+
+      max = verse.words_count || verse.words.count
+      reasons = []
+      reasons << "from > to (#{phrase.word_position_from} > #{phrase.word_position_to})" if phrase.word_position_from > phrase.word_position_to
+      reasons << "to > words_count (#{phrase.word_position_to} > #{max})" if phrase.word_position_to > max
+
+      next if reasons.empty?
+
+      bad_phrases << {
+        id: phrase.id,
+        verse_key: verse.verse_key,
+        words_count: max,
+        range: [phrase.word_position_from, phrase.word_position_to],
+        approved: phrase.approved,
+        reasons: reasons
+      }
+    end
+
+    if bad_phrases.empty?
+      puts '  no invalid phrase source ranges'
+    else
+      puts "  #{bad_phrases.size} invalid phrase source range(s):"
+      bad_phrases.each do |row|
+        puts "    phrase ##{row[:id]} approved=#{row[:approved]} #{row[:verse_key]} (#{row[:words_count]} words) range=#{row[:range].inspect} — #{row[:reasons].join(', ')}"
+      end
+    end
+
+    puts ''
+    puts 'Scanning Morphology::PhraseVerse ranges...'
+    bad_verses = []
+    Morphology::PhraseVerse.includes(:verse).find_each do |phrase_verse|
+      verse = phrase_verse.verse
+      next unless verse && phrase_verse.word_position_from && phrase_verse.word_position_to
+
+      max = verse.words_count || verse.words.count
+      reasons = []
+      reasons << "from > to (#{phrase_verse.word_position_from} > #{phrase_verse.word_position_to})" if phrase_verse.word_position_from > phrase_verse.word_position_to
+      reasons << "to > words_count (#{phrase_verse.word_position_to} > #{max})" if phrase_verse.word_position_to > max
+
+      next if reasons.empty?
+
+      bad_verses << {
+        id: phrase_verse.id,
+        phrase_id: phrase_verse.phrase_id,
+        verse_key: verse.verse_key,
+        words_count: max,
+        range: [phrase_verse.word_position_from, phrase_verse.word_position_to],
+        approved: phrase_verse.approved,
+        reasons: reasons
+      }
+    end
+
+    if bad_verses.empty?
+      puts '  no invalid phrase_verse ranges'
+    else
+      puts "  #{bad_verses.size} invalid phrase_verse range(s):"
+      bad_verses.each do |row|
+        puts "    phrase_verse ##{row[:id]} phrase=#{row[:phrase_id]} approved=#{row[:approved]} #{row[:verse_key]} (#{row[:words_count]} words) range=#{row[:range].inspect} — #{row[:reasons].join(', ')}"
+      end
+    end
+
+    total = bad_phrases.size + bad_verses.size
+    if total.positive?
+      puts ''
+      puts "Found #{total} invalid range(s)."
+      exit 1
+    end
+  end
+end


### PR DESCRIPTION
Closes / supersedes the discussion on #542.

Two pieces, both opt-in for existing data so this doesn't break anything already in the database:

### 1. Model-level validation

`Morphology::Phrase` (source range) and `Morphology::PhraseVerse` (matched range) get the same shape of check:

```ruby
validate :word_position_range_within_<verse>,
         if: :should_validate_word_position_range?

# fires only when:
#   - the record is new, OR
#   - word_position_from / word_position_to changed, OR
#   - approved is being flipped to true
```

Validation errors include the verse key and the verse's `words_count` so the admin gets actionable feedback:

```
word_position_to is 27 but 48:10 only has 26 words
word_position_to must be >= word_position_from (5)
```

The `if:` guard means existing rows can still be loaded/touched without the validation rejecting them — only writes that *introduce or change* a bad range, or *approve* one, are blocked. That matches the reporter's "small check at creation/CMS/tool level" without back-pressure on the rest of the catalogue.

### 2. Audit rake task

```
bundle exec rake mutashabihat:audit_ranges
```

Walks every `Morphology::Phrase` and `Morphology::PhraseVerse`, prints any record whose range is monotonically wrong (`from > to`) or out-of-bounds (`to > verse.words_count`), and exits non-zero if anything is found. Ready to wire into a periodic sanity job if you want.

Sample format (using the values from the issue):

```
phrase #12345 approved=true 48:10 (26 words) range=[23, 27] — to > words_count (27 > 26)
phrase #67890 approved=true 48:24 (20 words) range=[17, 21] — to > words_count (21 > 20)
```

### Not covered intentionally

- The "word number included vs excluded at verse boundary" inconsistency (29:25, 4:33, 10:31, 10:23 in the issue log) is a data-canonicalization decision, not something the model can enforce — left to the maintainer to confirm which side of the convention is canonical.
- No bulk migration to fix the existing ~7 invalid rows the reporter logged. The audit task surfaces them; the actual repair can be data-side once you've decided the desired range.

### Verification

`ruby -c` clean on both edited models and the rake file. Behaviour-checking the validation needs a running DB (mini dump didn't load locally this session due to a Docker port conflict — happy to verify end-to-end once you confirm the approach is what you wanted).
