### PR TITLE
Remove zeet PR builds host

### DIFF
--- a/config/initializers/hosts.rb
+++ b/config/initializers/hosts.rb
@@ -3,16 +3,9 @@ env = Rails.env
 host = env.development? ? 'localhost:3000' : 'qul.tarteel.ai'
 
 Rails.application.configure do
-  hosts = [/.*\.tarteel-v3\.tarteel\.io/, 'qul.tarteel.ai', 'localhost']
+  hosts = ['qul.tarteel.ai', 'localhost']
   config.hosts += hosts
   config.action_cable.allowed_request_origins = hosts
-
-=begin
-  config.action_dispatch.default_headers = {
-    'Access-Control-Allow-Origin' => '*',
-    'X-Forwarded-Proto' => 'https'
-  }
-=end
 
   if env.production? || env.staging?
     config.action_mailer.default_url_options = {


### PR DESCRIPTION
We've migrated off of zeet, this PR remove the zeet PR builds host.