### PR TITLE
Fix WebGL context error on Turbo-cached landing page (#448)

### DIFF
--- a/app/javascript/controllers/spline_viewer_controller.js
+++ b/app/javascript/controllers/spline_viewer_controller.js
@@ -1,11 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
 export default class extends Controller {
-  static targets = ["fallback", "container", "viewer"];
+  static targets = ["fallback", "container", "mount", "template"];
 
   connect() {
     this.loaded = false;
     this.observer = null;
+    this.boundHandleResize = this.handleResize.bind(this);
+    this.boundBeforeCache = this.teardown.bind(this);
 
     if (this.isSmallScreen()) {
       this.showFallback();
@@ -13,13 +15,21 @@ export default class extends Controller {
       this.lazyLoadSpline();
     }
 
-    window.addEventListener("resize", this.handleResize.bind(this));
+    window.addEventListener("resize", this.boundHandleResize);
+
+    // Turbo snapshots the page into its cache on navigation. A live <spline-viewer>
+    // restored from that snapshot re-initializes its WebGL canvas and throws
+    // "Canvas has an existing context of a different type" (issue #448), so tear the
+    // viewer down before the snapshot is taken and rebuild it when we reconnect.
+    document.addEventListener("turbo:before-cache", this.boundBeforeCache);
   }
 
   disconnect() {
-    window.removeEventListener("resize", this.handleResize.bind(this));
+    window.removeEventListener("resize", this.boundHandleResize);
+    document.removeEventListener("turbo:before-cache", this.boundBeforeCache);
     if (this.observer) {
       this.observer.disconnect();
+      this.observer = null;
     }
   }
 
@@ -69,6 +79,7 @@ export default class extends Controller {
   loadSpline() {
     this.loaded = true;
     this.showSpline();
+    this.renderViewer();
 
     if (!window.customElements.get("spline-viewer")) {
       const script = document.createElement("script");
@@ -77,6 +88,29 @@ export default class extends Controller {
         "https://unpkg.com/@splinetool/viewer/build/spline-viewer.js";
       document.head.appendChild(script);
     }
+  }
+
+  // Build the <spline-viewer> from its template into the mount point.
+  renderViewer() {
+    if (!this.hasMountTarget || !this.hasTemplateTarget) return;
+    if (this.mountTarget.querySelector("spline-viewer")) return;
+
+    this.mountTarget.appendChild(this.templateTarget.content.cloneNode(true));
+  }
+
+  // Remove the live viewer (and its WebGL canvas) so it is not restored from the Turbo cache.
+  teardown() {
+    if (this.observer) {
+      this.observer.disconnect();
+      this.observer = null;
+    }
+    this.loaded = false;
+
+    if (this.hasMountTarget) {
+      this.mountTarget.replaceChildren();
+    }
+
+    this.showFallback();
   }
 
   handleResize() {

--- a/app/views/landing/_spline.html.erb
+++ b/app/views/landing/_spline.html.erb
@@ -6,14 +6,20 @@
     data-spline-viewer-target="fallback"
   />
   <div class="hidden lg:block w-full h-full" data-spline-viewer-target="container">
-    <div class="w-full h-full flex justify-center items-center">
-      <spline-viewer
-        url="https://static-cdn.tarteel.ai/qul/spline/scene.splinecode"
-        width="800"
-        height="800"
-        class="scale-75 md:scale-100"
-        data-spline-viewer-target="viewer"
-      ></spline-viewer>
-    </div>
+    <div
+      class="w-full h-full flex justify-center items-center"
+      data-spline-viewer-target="mount"
+    ></div>
   </div>
+
+  <%# Kept in an inert <template> so the <spline-viewer> WebGL canvas is created lazily
+      and can be torn down before Turbo caches the page (see spline_viewer_controller). %>
+  <template data-spline-viewer-target="template">
+    <spline-viewer
+      url="https://static-cdn.tarteel.ai/qul/spline/scene.splinecode"
+      width="800"
+      height="800"
+      class="scale-75 md:scale-100"
+    ></spline-viewer>
+  </template>
 </div>


### PR DESCRIPTION
## Description

The landing-page hero loads a `<spline-viewer>` (Spline 3D scene) lazily. Because the viewer element lived directly in the DOM, Turbo included its WebGL canvas in the page snapshot it caches on navigation. When the user navigated away and came back, Turbo restored that snapshot and the `spline-viewer` custom element re-initialized on a canvas that already had a context, throwing:

```
THREE.WebGLRenderer: A WebGL context could not be created.
Reason: Canvas has an existing context of a different type
```

This change:

- Moves the `<spline-viewer>` markup into an inert `<template>` and builds it lazily into a dedicated mount point.
- Tears the viewer (and its WebGL canvas) down on `turbo:before-cache`, so the cached snapshot never contains a live canvas, and rebuilds it when the Stimulus controller reconnects.
- Binds the `resize`/teardown handlers once so `removeEventListener` actually detaches them (the previous `this.handleResize.bind(this)` created a new function on each call and never removed the listener).

## Related Issue

Fixes #448

## Motivation and Context

Returning to the home page via Turbo navigation broke the Spline animation and logged a WebGL error in production (Chrome/Edge). The fix follows the approach suggested in the issue: remove the Spline canvas before the page is cached, then recreate it cleanly afterward.

## How Has This Been Tested?

- `npx esbuild app/javascript/controllers/spline_viewer_controller.js --bundle` compiles with no errors.
- Verified the lazy-load + small-screen fallback paths still hold and that no other code references the removed `viewer` target.
- Reasoned through the Turbo cache lifecycle (`turbo:before-cache` fires before the snapshot; the controller reconnects on restore and rebuilds from the template).

## Screenshots (if appropriate):

N/A — no visual change in normal use; the fix prevents the WebGL error on cached-page restoration.
