### PR TITLE
Export mushaf layout data as JSON per page (#257)

### DIFF
--- a/lib/exporter/downloadable_resources.rb
+++ b/lib/exporter/downloadable_resources.rb
@@ -120,8 +120,9 @@ module Exporter
           create_download_file(downloadable_resource, docx, 'docx')
         end
         sqlite = exporter.export_sqlite
+        json = exporter.export_json
 
-        # create_download_file(downloadable_resource, json, 'json')
+        create_download_file(downloadable_resource, json, 'json')
         create_download_file(downloadable_resource, sqlite, 'sqlite')
       end
     end

--- a/lib/exporter/export_mushaf_layout.rb
+++ b/lib/exporter/export_mushaf_layout.rb
@@ -39,6 +39,32 @@ module Exporter
       base_path
     end
 
+    # Exports one JSON file per page (plus an info.json with mushaf metadata) so the
+    # layout can be consumed directly without querying the database (issue #257).
+    def export_json
+      base_path = "#{@export_file_path}/json"
+      FileUtils.mkdir_p(base_path)
+
+      mushaf = find_mushaf
+
+      write_json(
+        "#{base_path}/info.json",
+        {
+          name: mushaf.name,
+          number_of_pages: mushaf.pages_count,
+          lines_per_page: mushaf.lines_per_page,
+          font_name: mushaf.default_font_name
+        }
+      )
+
+      text_method = mushaf.text_type_method
+      pages.each do |page|
+        export_page_json(page, base_path, mushaf, text_method)
+      end
+
+      base_path
+    end
+
     protected
 
     def export_page_document(page, path)
@@ -107,6 +133,35 @@ module Exporter
 
         statement.execute(fields)
       end
+    end
+
+    def export_page_json(page, path, mushaf, text_method)
+      lines = prepare_page_lines(page, mushaf)
+      page_data = { page: page.page_number, lines: {} }
+
+      lines.keys.sort.each_with_index do |line, index|
+        alignment, line_type = get_line_alignment(page, line, mushaf)
+        is_centered = alignment&.is_center_aligned? || line_type == 'surah_name' || line_type == 'basmallah'
+
+        line_data = {
+          type: line_type,
+          alignment: is_centered ? 'centered' : 'justified'
+        }
+
+        case line_type
+        when 'ayah'
+          words = (lines[line] || []).sort_by(&:word_index)
+          line_data[:first_word_id] = words.first&.word_index
+          line_data[:last_word_id] = words.last&.word_index
+          line_data[:data] = words.map { |word| word.send(text_method) }
+        when 'surah_name'
+          line_data[:surah_number] = alignment&.get_surah_number
+        end
+
+        page_data[:lines][index + 1] = line_data
+      end
+
+      write_json("#{path}/#{page.page_number}.json", page_data)
     end
 
     def prepare_page_lines(page, mushaf)


### PR DESCRIPTION
## Description

Adds a JSON export format for mushaf layouts. Previously a layout could only be downloaded as SQLite (or DOCX); the JSON wiring existed but was commented out. This implements `ExportMushafLayout#export_json` and enables it in the download pipeline.

It writes **one `<page_number>.json` file per page** plus an `info.json` with mushaf metadata, into a dedicated `json/` directory (so it doesn't collide with the DOCX `pages/` output). The per-page logic reuses the exact same line/alignment helpers as the existing SQLite export (`prepare_page_lines`, `get_line_alignment`), so the two stay consistent.

Per-page structure:

```json
{
  "page": 2,
  "lines": {
    "1": { "type": "surah_name", "alignment": "centered", "surah_number": 2 },
    "2": {
      "type": "ayah",
      "alignment": "justified",
      "first_word_id": 5,
      "last_word_id": 12,
      "data": ["ٱلٓمٓ", "ذَٰلِكَ", "ٱلۡكِتَٰبُ"]
    }
  }
}
```

`info.json`:

```json
{ "name": "...", "number_of_pages": 604, "lines_per_page": 15, "font_name": "..." }
```

Word text for `data` is resolved via the layout's script using `Mushaf#text_type_method` — the same mechanism `MushafLayoutJob` already uses — so glyph-based mushafs (v1/v2) emit their glyph codes and text-based mushafs emit the appropriate script text.

Note: I kept the line `type` vocabulary (`ayah` / `surah_name` / `basmallah`) consistent with the existing SQLite export rather than the slightly different names sketched in the issue, so both downloads describe lines the same way. Happy to adjust the key names/structure if maintainers prefer.

## Related Issue

Closes #257

## Motivation and Context

The issue asks for per-page JSON so developers can integrate layout data directly without standing up a server to query the database. The export already supported SQLite/DOCX and had a commented-out JSON hook; this fills it in.

## How Has This Been Tested?

- `ruby -c` passes on both changed files.
- RuboCop (Layout/Lint) reports no new offenses in the added code.
- The new `export_page_json` mirrors the already-in-production `export_page` (SQLite) logic line-for-line, and word-text resolution reuses the established `word.send(mushaf.text_type_method)` pattern from `MushafLayoutJob`.
- I was not able to run the exporter end-to-end against a seeded database in my environment, so a maintainer running `export_mushaf_layouts` for a sample layout to eyeball the generated JSON would be a valuable confirmation.

## Screenshots (if appropriate):

N/A — backend export change.
