### PR TITLE
Replace Spline WebGL viewer with a lightweight video

### DIFF
--- a/app/javascript/controllers/spline_viewer_controller.js
+++ b/app/javascript/controllers/spline_viewer_controller.js
@@ -10,7 +10,7 @@ export default class extends Controller {
   static values = {
     maxTilt: { type: Number, default: 14 },
     restScale: { type: Number, default: 0.92 },
-    hoverScale: { type: Number, default: 0.82 },
+    hoverScale: { type: Number, default: 0.85 },
     // When disabled (default), the video is used on every screen size. Enable
     // to fall back to the static image on small screens instead.
     fallback: { type: Boolean, default: false },

--- a/app/javascript/controllers/spline_viewer_controller.js
+++ b/app/javascript/controllers/spline_viewer_controller.js
@@ -1,32 +1,51 @@
 import { Controller } from "@hotwired/stimulus";
 
+// Renders the landing hero background. Originally a heavy <spline-viewer> WebGL
+// scene; now a lazy-loaded autoplaying video. The video keeps a subtle
+// mouse-follow tilt (via a CSS 3D transform) to echo the interactivity the
+// Spline scene had, while being far cheaper to render.
 export default class extends Controller {
-  static targets = ["fallback", "container", "mount", "template"];
+  static targets = ["fallback", "container", "video"];
+
+  static values = {
+    maxTilt: { type: Number, default: 14 },
+    restScale: { type: Number, default: 0.92 },
+    hoverScale: { type: Number, default: 0.82 },
+    // When disabled (default), the video is used on every screen size. Enable
+    // to fall back to the static image on small screens instead.
+    fallback: { type: Boolean, default: false },
+  };
 
   connect() {
     this.loaded = false;
+    this.tiltEnabled = false;
     this.observer = null;
+    this.frame = null;
+    this.pendingTilt = { nx: 0, ny: 0 };
+
     this.boundHandleResize = this.handleResize.bind(this);
     this.boundBeforeCache = this.teardown.bind(this);
+    this.boundPointerMove = this.handlePointerMove.bind(this);
+    this.boundResetTilt = this.resetTilt.bind(this);
 
-    if (this.isSmallScreen()) {
+    if (this.shouldUseFallback()) {
       this.showFallback();
     } else {
-      this.lazyLoadSpline();
+      this.lazyLoadVideo();
+      this.enableTilt();
     }
 
     window.addEventListener("resize", this.boundHandleResize);
 
-    // Turbo snapshots the page into its cache on navigation. A live <spline-viewer>
-    // restored from that snapshot re-initializes its WebGL canvas and throws
-    // "Canvas has an existing context of a different type" (issue #448), so tear the
-    // viewer down before the snapshot is taken and rebuild it when we reconnect.
+    // Pause/clean up before Turbo snapshots the page so the cached snapshot
+    // isn't restored mid-playback. We rebuild on reconnect.
     document.addEventListener("turbo:before-cache", this.boundBeforeCache);
   }
 
   disconnect() {
     window.removeEventListener("resize", this.boundHandleResize);
     document.removeEventListener("turbo:before-cache", this.boundBeforeCache);
+    this.disableTilt();
     if (this.observer) {
       this.observer.disconnect();
       this.observer = null;
@@ -35,6 +54,12 @@ export default class extends Controller {
 
   isSmallScreen() {
     return window.innerWidth < 1024;
+  }
+
+  // Only fall back to the static image when the fallback setting is enabled
+  // and we're on a small screen; otherwise the video plays everywhere.
+  shouldUseFallback() {
+    return this.fallbackValue && this.isSmallScreen();
   }
 
   showFallback() {
@@ -46,7 +71,7 @@ export default class extends Controller {
     }
   }
 
-  showSpline() {
+  showVideo() {
     if (this.hasFallbackTarget) {
       this.fallbackTarget.classList.add("hidden");
     }
@@ -55,16 +80,21 @@ export default class extends Controller {
     }
   }
 
-  lazyLoadSpline() {
+  lazyLoadVideo() {
     if (this.loaded) return;
+
+    // The poster (same image as the fallback) shows immediately, so revealing
+    // the container before the source loads is seamless.
+    this.showVideo();
 
     if ("IntersectionObserver" in window) {
       this.observer = new IntersectionObserver(
         (entries) => {
           entries.forEach((entry) => {
             if (entry.isIntersecting) {
-              this.loadSpline();
+              this.loadVideo();
               this.observer.disconnect();
+              this.observer = null;
             }
           });
         },
@@ -72,54 +102,136 @@ export default class extends Controller {
       );
       this.observer.observe(this.containerTarget);
     } else {
-      this.loadSpline();
+      this.loadVideo();
     }
   }
 
-  loadSpline() {
+  loadVideo() {
     this.loaded = true;
-    this.showSpline();
-    this.renderViewer();
+    if (!this.hasVideoTarget) return;
 
-    if (!window.customElements.get("spline-viewer")) {
-      const script = document.createElement("script");
-      script.type = "module";
-      script.src =
-        "https://unpkg.com/@splinetool/viewer/build/spline-viewer.js";
-      document.head.appendChild(script);
+    const source = this.videoTarget.querySelector("source[data-src]");
+    if (source && !source.src) {
+      source.src = source.dataset.src;
+      this.videoTarget.load();
+    }
+
+    this.playVideo();
+  }
+
+  playVideo() {
+    if (!this.hasVideoTarget) return;
+    const playback = this.videoTarget.play();
+    // Autoplay can be rejected (e.g. low-power mode); the poster stays visible.
+    if (playback && typeof playback.catch === "function") {
+      playback.catch(() => {});
     }
   }
 
-  // Build the <spline-viewer> from its template into the mount point.
-  renderViewer() {
-    if (!this.hasMountTarget || !this.hasTemplateTarget) return;
-    if (this.mountTarget.querySelector("spline-viewer")) return;
+  // --- Mouse-follow tilt -----------------------------------------------------
 
-    this.mountTarget.appendChild(this.templateTarget.content.cloneNode(true));
+  enableTilt() {
+    if (this.tiltEnabled) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    if (window.matchMedia("(hover: none)").matches) return;
+
+    if (!this.hasContainerTarget) return;
+
+    this.tiltEnabled = true;
+    this.resetTilt();
+    this.containerTarget.addEventListener("pointermove", this.boundPointerMove);
+    this.containerTarget.addEventListener("pointerleave", this.boundResetTilt);
   }
 
-  // Remove the live viewer (and its WebGL canvas) so it is not restored from the Turbo cache.
+  disableTilt() {
+    if (!this.tiltEnabled) return;
+    this.tiltEnabled = false;
+    if (this.hasContainerTarget) {
+      this.containerTarget.removeEventListener("pointermove", this.boundPointerMove);
+      this.containerTarget.removeEventListener("pointerleave", this.boundResetTilt);
+    }
+    if (this.frame) {
+      cancelAnimationFrame(this.frame);
+      this.frame = null;
+    }
+    this.resetTilt();
+  }
+
+  handlePointerMove(event) {
+    if (!this.hasContainerTarget) return;
+
+    const rect = this.containerTarget.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    // Normalized -1..1 distance from the container's center, clamped so the
+    // tilt saturates when the pointer is far away (e.g. over the hero text).
+    const nx = clamp((event.clientX - cx) / (rect.width / 2), -1, 1);
+    const ny = clamp((event.clientY - cy) / (rect.height / 2), -1, 1);
+
+    this.pendingTilt = { nx, ny };
+    if (this.frame) return;
+    this.frame = requestAnimationFrame(() => {
+      this.frame = null;
+      this.applyTilt(this.pendingTilt.nx, this.pendingTilt.ny);
+    });
+  }
+
+  applyTilt(nx, ny) {
+    if (!this.hasVideoTarget) return;
+    const max = this.maxTiltValue;
+    // Horizontal movement tilts a little harder than vertical so the
+    // left/right follow reads clearly.
+    const rotateY = nx * max * 1.3;
+    const rotateX = -ny * max;
+    this.videoTarget.style.transform =
+      `rotateX(${rotateX.toFixed(2)}deg) rotateY(${rotateY.toFixed(2)}deg) scale(${this.hoverScaleValue})`;
+  }
+
+  resetTilt() {
+    if (this.hasVideoTarget) {
+      this.videoTarget.style.transform =
+        `rotateX(0deg) rotateY(0deg) scale(${this.restScaleValue})`;
+    }
+  }
+
+  // --- Lifecycle -------------------------------------------------------------
+
+  // Pause and reset for the Turbo cache snapshot; connect() rebuilds it.
   teardown() {
     if (this.observer) {
       this.observer.disconnect();
       this.observer = null;
     }
     this.loaded = false;
-
-    if (this.hasMountTarget) {
-      this.mountTarget.replaceChildren();
+    if (this.hasVideoTarget) {
+      this.videoTarget.pause();
     }
-
-    this.showFallback();
+    // Keep the video (with its poster) in the snapshot unless we'd genuinely
+    // fall back; connect() reloads/replays on reconnect.
+    if (this.shouldUseFallback()) {
+      this.showFallback();
+    }
   }
 
   handleResize() {
-    if (this.isSmallScreen()) {
+    if (this.shouldUseFallback()) {
+      this.disableTilt();
       this.showFallback();
-    } else if (!this.loaded) {
-      this.lazyLoadSpline();
+      if (this.hasVideoTarget) this.videoTarget.pause();
     } else {
-      this.showSpline();
+      this.enableTilt();
+      if (!this.loaded) {
+        this.lazyLoadVideo();
+      } else {
+        this.showVideo();
+        this.playVideo();
+      }
     }
   }
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
 }

--- a/app/views/landing/_spline.html.erb
+++ b/app/views/landing/_spline.html.erb
@@ -5,7 +5,7 @@
 >
   <img
     src="/spline.webp"
-    alt="Quranic Universal Library 3D Scene"
+    alt="Quranic Universal Library"
     class="hidden w-full h-full object-cover"
     data-spline-viewer-target="fallback"
   />
@@ -21,7 +21,7 @@
       aria-hidden="true"
     >
       <source
-        data-src="https://static-cdn.tarteel.ai/qul/spline/qul-spline.mp4"
+        data-src="https://static-cdn.tarteel.ai/qul/spline/spline-video.mp4"
         type="video/mp4"
       />
     </video>

--- a/app/views/landing/_spline.html.erb
+++ b/app/views/landing/_spline.html.erb
@@ -1,25 +1,29 @@
-<div data-controller="spline-viewer" class="w-full h-full flex justify-center items-center">
+<div
+  data-controller="spline-viewer"
+  data-spline-viewer-fallback-value="false"
+  class="w-full h-full flex justify-center items-center"
+>
   <img
     src="/spline.webp"
     alt="Quranic Universal Library 3D Scene"
-    class="w-full h-full object-cover"
+    class="hidden w-full h-full object-cover"
     data-spline-viewer-target="fallback"
   />
-  <div class="hidden lg:block w-full h-full" data-spline-viewer-target="container">
-    <div
-      class="w-full h-full flex justify-center items-center"
-      data-spline-viewer-target="mount"
-    ></div>
+  <div class="w-full h-full [perspective:1200px]" data-spline-viewer-target="container">
+    <video
+      data-spline-viewer-target="video"
+      class="w-full h-full object-contain will-change-transform transition-transform duration-300 ease-out"
+      muted
+      loop
+      playsinline
+      preload="none"
+      poster="/spline.webp"
+      aria-hidden="true"
+    >
+      <source
+        data-src="https://static-cdn.tarteel.ai/qul/spline/qul-spline.mp4"
+        type="video/mp4"
+      />
+    </video>
   </div>
-
-  <%# Kept in an inert <template> so the <spline-viewer> WebGL canvas is created lazily
-      and can be torn down before Turbo caches the page (see spline_viewer_controller). %>
-  <template data-spline-viewer-target="template">
-    <spline-viewer
-      url="https://static-cdn.tarteel.ai/qul/spline/scene.splinecode"
-      width="800"
-      height="800"
-      class="scale-75 md:scale-100"
-    ></spline-viewer>
-  </template>
 </div>


### PR DESCRIPTION
Replace the `<spline-viewer>` WebGL animation on landing and auth pages with a lightweight autoplaying MP4 (~600 KB) video.

The Spline scene was visually appealing but caused performance and reliability issues:

* Slow page loads and occasional freezes.
* Animation sometimes failed to load.
* Inconsistent support on older browsers.
* Previously disabled on smaller screens due to performance constraints.

## Changes

* Replace Spline with an MP4 video.
* Video is lazy loaded via `IntersectionObserver`.
* Preserve mouse-follow interaction using CSS 3D transforms (tilt + scale).
* Respect `prefers-reduced-motion` and disable tilt on touch devices.
* Video now plays on all screen sizes by default; optional `fallback` setting can show a static image on small screens.

## Screenshots
| Spline | MP4 |
|--------|--------|
| <img width="1610" height="654" alt="image" src="https://github.com/user-attachments/assets/8a783f20-3cc7-468d-86cc-7696e955be25" /> | <img width="1599" height="653" alt="image" src="https://github.com/user-attachments/assets/2d7d5313-29ef-46ea-b3ee-5726a0018fbe" /> | 