### PR TITLE
Fix audio file duration and other metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,6 @@ gem 'csv', require: false
 
 # metadata for audio file
 gem 'streamio-ffmpeg', '~> 3.0', require:  false
-gem 'wahwah', require: false
 gem 'dalli'
 gem 'diffy'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -564,7 +564,6 @@ GEM
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1.0)
       method_source (~> 1.0)
-    wahwah (1.3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -663,7 +662,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicode-name
   view_component (~> 3.21)
-  wahwah
   web-console
 
 RUBY VERSION

--- a/lib/audio/audio_file_meta_data.rb
+++ b/lib/audio/audio_file_meta_data.rb
@@ -1,65 +1,37 @@
-require 'wahwah'
+require 'open3'
+require 'json'
 
 module Audio
   class AudioFileMetaData
-    attr_reader :tmp_dir,
-                :recitation
+    attr_reader :recitation
 
     def initialize(recitation:)
       @recitation = recitation
-      @tmp_dir = "tmp/audio_meta_data/#{recitation.id}"
-      FileUtils.mkdir_p(tmp_dir)
     end
 
     def update_meta_data(options={})
       if recitation.one_ayah?
         update_ayah_audio_meta_data(chapter_id: options[:chapter_id], force: options[:force])
         segments = AudioSegment::AyahByAyah.new(recitation)
-        segments.track_repetition(chapter_id: options[:chapter_id])
       else
         update_surah_audio_meta_data(chapter_id: options[:chapter_id], force: options[:force])
         segments = AudioSegment::SurahBySurah.new(recitation)
-        segments.track_repetition(chapter_id: options[:chapter_id])
       end
 
-      clean_up
+      segments.track_repetition(chapter_id: options[:chapter_id])
     end
 
     protected
 
     def update_surah_audio_meta_data(chapter_id: nil, force: false)
       audio_files = Audio::ChapterAudioFile.where(audio_recitation: recitation)
-
-      if chapter_id
-        audio_files = audio_files.where(chapter_id: chapter_id)
-      end
+      audio_files = audio_files.where(chapter_id: chapter_id) if chapter_id
 
       audio_files.each do |audio_file|
         next if !force && audio_file.has_audio_meta_data?
 
-        url = audio_file.audio_url
         audio_file.update_segment_percentile
-
-        if meta_response = fetch_audio_file_meta_data(url)
-          file = meta_response[:file]
-
-          meta = WahWah.open(file)
-          duration = (meta.duration || calculate_duration(file)).to_f
-
-          audio_file.attributes = {
-            file_size: meta_response[:size].to_i,
-            bit_rate: meta.bitrate,
-            duration: duration.round(2),
-            duration_ms: (duration * 1000).to_i,
-            mime_type: MIME::Types.type_for(file).first.content_type,
-            meta_data: prepare_surah_audio_meta_data(
-              audio_file: audio_file,
-              meta: meta
-            )
-          }
-        end
-
-        audio_file.save(validate: false)
+        update_audio_file_meta_data(audio_file)
       end
     end
 
@@ -67,60 +39,42 @@ module Audio
       audio_files = AudioFile
                       .includes(:verse, :chapter)
                       .where(recitation_id: recitation.id)
-
-      if chapter_id
-        audio_files = audio_files.where(chapter_id: chapter_id)
-      end
+      audio_files = audio_files.where(chapter_id: chapter_id) if chapter_id
 
       audio_files.find_each do |audio_file|
         next if !force && audio_file.has_audio_meta_data?
-        url = audio_file.audio_url
 
-        if meta_response = fetch_audio_file_meta_data(url)
-          file = meta_response[:file]
-
-          meta = WahWah.open(file)
-          duration = (meta.duration || calculate_duration(file)).to_f
-
-          audio_file.attributes = {
-            file_size: meta_response[:size].to_i,
-            bit_rate: meta.bitrate,
-            duration: duration.round(2),
-            duration_ms: (duration * 1000).to_i,
-            mime_type: MIME::Types.type_for(file).first.content_type,
-            meta_data: prepare_surah_meta_data(
-              audio_file: audio_file,
-              meta: meta
-            )
-          }
-
-          audio_file.save(validate: false)
-        end
+        update_audio_file_meta_data(audio_file)
       end
     end
 
-    def clean_up
-      FileUtils.rm_rf(tmp_dir)
+    def update_audio_file_meta_data(audio_file)
+      meta = fetch_audio_file_metadata(audio_file.audio_url)
+      return unless meta
+
+      duration = (meta[:duration_ms].to_f / 1000)
+
+      audio_file.attributes = {
+        file_size: meta[:size_bytes],
+        bit_rate: meta[:bitrate],
+        duration: duration.round(2),
+        duration_ms: meta[:duration_ms].to_i,
+        mime_type: meta[:mime_type],
+        meta_data: prepare_meta_data(audio_file: audio_file, meta: meta)
+      }
+
+      audio_file.save(validate: false)
     end
 
-    def prepare_surah_meta_data(audio_file:, meta:)
-      existing_meta = audio_file.meta_data || {}
-      chapter = audio_file.chapter
-
-      existing_meta.with_defaults_values({
-                                           album: "#{recitation.name} Quran recitation",
-                                           genre: "Quran",
-                                           title: chapter.name_simple,
-                                           track: "#{chapter.chapter_number}/114",
-                                           artist: recitation.name,
-                                           year: meta.year
-                                         })
-
-      existing_meta[:comment] = 'https://qul.tarteel.ai/'
-      existing_meta.to_h
+    def prepare_meta_data(audio_file:, meta:)
+      if recitation.one_ayah?
+        prepare_ayah_file_meta_data(audio_file: audio_file, meta: meta)
+      else
+        prepare_surah_file_meta_data(audio_file: audio_file, meta: meta)
+      end
     end
 
-    def prepare_surah_audio_meta_data(audio_file:, meta:)
+    def prepare_surah_file_meta_data(audio_file:, meta:)
       meta_data = audio_file.meta_data || {}
       chapter = audio_file.chapter
 
@@ -129,9 +83,9 @@ module Audio
           album: "#{recitation.name} Quran recitation",
           genre: "Quran",
           title: chapter.name_simple,
-          track: "114/#{chapter.id}",
+          track: "#{chapter.chapter_number}/114",
           artist: recitation.name,
-          year: meta.year
+          year: meta[:year]
         }
       )
 
@@ -139,41 +93,69 @@ module Audio
       meta_data.to_h
     end
 
-    def calculate_duration(audio_file)
-      # ffmpeg -i https://download.quranicaudio.com/quran/abdullaah_3awwaad_al-juhaynee/001.mp3 2>&1 | egrep "Duration"
+    def prepare_ayah_file_meta_data(audio_file:, meta:)
+      meta_data = audio_file.meta_data || {}
+      chapter = audio_file.chapter
+      ayah_number = audio_file.verse_number
 
-      result = `ffmpeg -i #{audio_file} 2>&1 | egrep "Duration"`
-      matched = result.match(/Duration:\s(?<h>(\d+)):(?<m>(\d+)):(?<s>(\d+))/)
-
-      (matched[:h].to_i * 3600) + (matched[:m].to_i * 60) + matched[:s].to_i
-    rescue Exception => e
-      nil
-    end
-
-    def fetch_audio_file_meta_data(url)
-      request = fetch_bytes(url, 5.megabyte)
-      body = request.body
-
-      if body.to_s.include?("Not Found")
-        return false
-      else
-        tmp_file_name = "audio-#{Time.now.to_i}.mp3"
-        File.open("#{tmp_dir}/#{tmp_file_name}", "wb") do |file|
-          file << body
-        end
-
+      meta_data.with_defaults_values(
         {
-          file: "#{tmp_dir}/#{tmp_file_name}",
-          size: request.response.header['content-length']
+          album: "#{recitation.name} Quran recitation",
+          genre: "Quran",
+          title: "#{chapter.name_simple} #{ayah_number}",
+          track: "#{chapter.verses_count}/#{ayah_number}",
+          artist: recitation.name,
+          year: meta[:year]
         }
-      end
+      )
+
+      meta_data[:comment] = 'https://qul.tarteel.ai/'
+      meta_data.to_h
     end
 
-    def fetch_bytes(url, size)
-      uri = URI(url)
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
-      http.get(url, { 'Range' => "bytes=0-#{size}" })
+    def fetch_audio_file_metadata(url)
+      stdout, status = Open3.capture2(
+        "ffprobe",
+        "-v", "quiet",
+        "-print_format", "json",
+        "-show_format",
+        "-show_streams",
+        url,
+      )
+
+      return nil unless status.success?
+
+      data = JSON.parse(stdout)
+
+      format = data["format"] || {}
+      stream = data["streams"]&.find { |s| s["codec_type"] == "audio" } || {}
+
+      tags = format["tags"] || stream["tags"] || {}
+
+      format_name = format["format_name"] || stream["codec_name"]
+
+      mime_type = case format_name
+                  when "mp3" then "audio/mpeg"
+                  when "wav" then "audio/wav"
+                  when "flac" then "audio/flac"
+                  when "ogg" then "audio/ogg"
+                  when "aac" then "audio/aac"
+                  when "mp4,m4a,3gp,3g2,mj2" then "audio/mp4"
+                  end
+
+      {
+        artist: tags["artist"],
+        year: tags["date"] || tags["year"],
+        size_bytes: format["size"]&.to_i,
+        duration_ms: (format["duration"].to_f * 1000).round,
+        sample_rate: stream["sample_rate"]&.to_i,
+        bitrate: (
+          stream["bit_rate"] ||
+          format["bit_rate"]
+        )&.to_i,
+        format: format_name,
+        mime_type: mime_type
+      }
     end
   end
 end


### PR DESCRIPTION
Previously, we used the `wahwah` gem to calculate audio duration. However, `wahwah` requires the complete audio file to be downloaded locally before it can read the metadata.

Downloading full surah file just to fetch meta info was overkill, we solved this by fetching first few mb of data and used to read metadata. Most metadata was correct but audio duration wasn't very accurate. 

This change replaces `wahwah` with `ffprobe`, which can extract metadata directly from the audio URL.