### PR TITLE
Allow multiple Regexp pattren in search

### DIFF
--- a/app/admin/audio/audio_recitation.rb
+++ b/app/admin/audio/audio_recitation.rb
@@ -18,7 +18,6 @@ ActiveAdmin.register Audio::Recitation do
                 :recitation_style_id,
                 :qirat_type_id,
                 :reciter_id,
-                :gapped_recitation_id,
                 :segment_locked
 
   scope :all
@@ -333,9 +332,6 @@ ActiveAdmin.register Audio::Recitation do
       f.input :qirat_type_id,
               as: :searchable_select,
               ajax: { resource: QiratType }
-      f.input :gapped_recitation_id,
-              as: :searchable_select,
-              ajax: { resource: Recitation }
     end
 
     f.actions

--- a/app/services/search/pattern.rb
+++ b/app/services/search/pattern.rb
@@ -1,6 +1,7 @@
 module Search
   class Pattern
     GAP = /(\{[^{}]*\}\*?|\*)/
+
     Token = Struct.new(:kind, :regex, :like, :word_gap)
 
     def initialize(query, exact: false)
@@ -77,6 +78,7 @@ module Search
         @tokens << Token.new(:gap, '.*?', '%', false)
       else
         spec = token[1...token.index('}')]
+
         @tokens << Token.new(:gap, "\\s+(?:\\S+\\s+)#{bound(spec)}", nil, true)
       end
     end

--- a/app/services/search/pattern.rb
+++ b/app/services/search/pattern.rb
@@ -1,7 +1,6 @@
 module Search
   class Pattern
     GAP = /(\{[^{}]*\}\*?|\*)/
-
     Token = Struct.new(:kind, :regex, :like, :word_gap)
 
     def initialize(query, exact: false)

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,7 +4,7 @@
   <h1 class="text-2xl font-bold text-gray-900 mb-6">Search the Quran</h1>
 
   <%= form_with url: search_path, method: :get, data: { turbo: false } do %>
-    <%= render 'shared/search_input', name: 'q', value: @query, placeholder: 'Search Quran text…' %>
+    <%= render 'shared/search_input', name: 'q', value: @query, placeholder: 'Search Quran text…', dir: 'auto' %>
 
     <div class="flex items-center gap-6 mt-4 flex-wrap">
       <label class="flex items-center gap-2 text-sm text-gray-700">

--- a/app/views/shared/_search_input.html.erb
+++ b/app/views/shared/_search_input.html.erb
@@ -4,6 +4,7 @@
   input_value = local_assigns.fetch(:value, nil)
   placeholder = local_assigns.fetch(:placeholder, 'Quick Search...')
   input_data = local_assigns.fetch(:data, {})
+  input_dir = local_assigns.fetch(:dir, nil)
 %>
 <div class="relative">
   <%= tag.input(
@@ -14,6 +15,7 @@
         name: input_name,
         value: input_value,
         autocomplete: 'off',
+        dir: input_dir,
         data: input_data
       ) %>
   <div class="absolute <%= variant == 'large' ? 'start-6 top-[1.65rem]' : 'start-5 top-[1.15rem]' %>">


### PR DESCRIPTION
- Fix search field text direction 
- Allow multiple regexp pattern(*,$,{><} etc) in search.   