### PR TITLE
feat: color links in docs website for better visibility 

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -79,7 +79,7 @@
   }
 
   .qul-docs a {
-    @apply underline font-bold;
+    @apply underline font-bold text-blue-600 hover:text-blue-800 visited:text-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2;
   }
 
   .btn {
@@ -104,6 +104,10 @@
 
   .tw-docs p {
     @apply mb-4;
+  }
+
+  .tw-docs a {
+    @apply underline text-blue-600 hover:text-blue-800 visited:text-purple-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2;
   }
 
   .tw-docs ul {


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/cde42ccd-c74c-4999-8f90-7d1253daa3dc" />| <img width="1920" height="869" alt="image" src="https://github.com/user-attachments/assets/ee2f2f8e-a93b-4b92-b0df-85079aec88c8" /> | 

improves link visibility on the documentation website by adding distinct link colors and interactive states.


