### PR TITLE
fix mismatched Discord invite links and standardize formatting

### DIFF
--- a/app/helpers/seo_helper.rb
+++ b/app/helpers/seo_helper.rb
@@ -66,11 +66,7 @@ module SeoHelper
           "@type": "ImageObject",
           url: "#{HOST}/favicon.svg"
         }
-      },
-      sameAs: [
-        "https://github.com/TarteelAI/quranic-universal-library",
-        "https://discord.gg/HAcGh8mfmj"
-      ]
+      }
     }.to_json.html_safe
   end
 end

--- a/app/views/docs/markdown/README.md
+++ b/app/views/docs/markdown/README.md
@@ -30,8 +30,8 @@ The pages here are published on the website at `/docs` and mirrored in the repos
 
 ## Primary Links
 
-- Project home: [https://qul.tarteel.ai/](https://qul.tarteel.ai/)
-- Resources directory: [https://qul.tarteel.ai/resources](https://qul.tarteel.ai/resources)
-- Source code: [https://github.com/TarteelAI/quranic-universal-library](https://github.com/TarteelAI/quranic-universal-library)
-- Issues: [https://github.com/TarteelAI/quranic-universal-library/issues](https://github.com/TarteelAI/quranic-universal-library/issues)
-- Community Discord: [https://discord.gg/HAcGh8mfmj](https://discord.gg/HAcGh8mfmj)
+- [Project home](https://qul.tarteel.ai/)
+- [Resources directory](https://qul.tarteel.ai/resources)
+- [Source code](https://github.com/TarteelAI/quranic-universal-library)
+- [Issues](https://github.com/TarteelAI/quranic-universal-library/issues)
+- [Community Discord](https://t.zip/discord?utm_source=github&utm_campaign=qul)

--- a/app/views/docs/markdown/api.md
+++ b/app/views/docs/markdown/api.md
@@ -18,5 +18,4 @@ The full specification — including implemented and proposed endpoints — is b
 
 - [https://github.com/TarteelAI/quranic-universal-library](https://github.com/TarteelAI/quranic-universal-library)
 
-Want to influence the API design? Share feedback on Discord:
-[https://discord.gg/HAcGh8mfmj](https://discord.gg/HAcGh8mfmj)
+Want to influence the API design? Share feedback on [Discord](https://t.zip/discord?utm_source=github&utm_campaign=qul)

--- a/app/views/docs/markdown/contribute-code.md
+++ b/app/views/docs/markdown/contribute-code.md
@@ -10,9 +10,9 @@ Help improve the QUL platform itself — the Rails app, tooling, exporters, and 
 
 ## Useful Links
 
-- Source code: [https://github.com/TarteelAI/quranic-universal-library](https://github.com/TarteelAI/quranic-universal-library)
-- Issues: [https://github.com/TarteelAI/quranic-universal-library/issues](https://github.com/TarteelAI/quranic-universal-library/issues)
-- Community Discord: [https://discord.gg/HAcGh8mfmj](https://discord.gg/HAcGh8mfmj)
+- [Source code](https://github.com/TarteelAI/quranic-universal-library)
+- [Issues](https://github.com/TarteelAI/quranic-universal-library/issues)
+- [Community Discord](https://t.zip/discord?utm_source=github&utm_campaign=qul)
 
 ## Looking to Improve Data Instead?
 

--- a/app/views/docs/markdown/contribute-data.md
+++ b/app/views/docs/markdown/contribute-data.md
@@ -23,5 +23,4 @@ Most data contribution happens through the QUL CMS, where each resource type has
 
 ## Get In Touch
 
-Join the community to coordinate larger data contributions:
-[https://discord.gg/HAcGh8mfmj](https://discord.gg/HAcGh8mfmj)
+Join the community on [Discord](https://t.zip/discord?utm_source=github&utm_campaign=qul) to coordinate larger data contributions.

--- a/app/views/landing/_header.html.erb
+++ b/app/views/landing/_header.html.erb
@@ -85,7 +85,7 @@
               <%= link_to 'Tools', tools_path, class: 'nav-link--drawer', data: { header_nav_target: 'tools' } %>
               <%= link_to 'Docs', docs_index_path, class: 'nav-link--drawer' %>
               <%= link_to 'Credits', credits_path, class: 'nav-link--drawer' %>
-              <%= link_to 'Community', 'https://t.zip/discord?utm_source=github&utm_campaign=qul', target: '_blank', class: 'text-black hover:text-[#46ac7a] transition-colors text-lg' %>
+              <%= link_to 'Community', 'https://t.zip/discord?utm_source=qul%20header&utm_campaign=qul', target: '_blank', class: 'text-black hover:text-[#46ac7a] transition-colors text-lg' %>
               <%= link_to 'FAQ', faq_path, class: 'nav-link--drawer', data: { header_nav_target: 'faq' } %>
               <%= link_to 'https://github.com/TarteelAI/quranic-universal-library', class: 'text-black hover:text-[#46ac7a] transition-colors text-lg flex items-center', target: '_blank' do %>
                 <span class="me-2">Github</span>

--- a/app/views/landing/_header.html.erb
+++ b/app/views/landing/_header.html.erb
@@ -21,7 +21,7 @@
         <%= link_to 'Resources', resources_path, class: 'nav-link--desktop', data: { header_nav_target: 'resources' } %>
         <%= link_to 'Tools', tools_path, class: 'nav-link--desktop', data: { header_nav_target: 'tools' } %>
         <%= link_to 'Docs', docs_index_path, class: 'nav-link--desktop' %>
-        <%= link_to 'Community', 'https://discord.gg/HAcGh8mfmj', target: '_blank', class: 'text-black hover:text-[#46ac7a] transition-colors hidden md:flex' %>
+        <%= link_to 'Community', 'https://t.zip/discord?utm_source=github&utm_campaign=qul', target: '_blank', class: 'text-black hover:text-[#46ac7a] transition-colors hidden md:flex' %>
         <%= link_to 'FAQ', faq_path, class: 'nav-link--desktop', data: { header_nav_target: 'faq' } %>
         <%= link_to 'https://github.com/TarteelAI/quranic-universal-library', class: 'text-black hover:text-[#46ac7a] transition-colors hidden md:flex items-center', target: '_blank' do %>
           <span class="me-2">Github</span>
@@ -85,7 +85,7 @@
               <%= link_to 'Tools', tools_path, class: 'nav-link--drawer', data: { header_nav_target: 'tools' } %>
               <%= link_to 'Docs', docs_index_path, class: 'nav-link--drawer' %>
               <%= link_to 'Credits', credits_path, class: 'nav-link--drawer' %>
-              <%= link_to 'Community', 'https://discord.gg/HAcGh8mfmj', target: '_blank', class: 'text-black hover:text-[#46ac7a] transition-colors text-lg' %>
+              <%= link_to 'Community', 'https://t.zip/discord?utm_source=github&utm_campaign=qul', target: '_blank', class: 'text-black hover:text-[#46ac7a] transition-colors text-lg' %>
               <%= link_to 'FAQ', faq_path, class: 'nav-link--drawer', data: { header_nav_target: 'faq' } %>
               <%= link_to 'https://github.com/TarteelAI/quranic-universal-library', class: 'text-black hover:text-[#46ac7a] transition-colors text-lg flex items-center', target: '_blank' do %>
                 <span class="me-2">Github</span>

--- a/app/views/user_mailer/thank_you.html.erb
+++ b/app/views/user_mailer/thank_you.html.erb
@@ -26,7 +26,7 @@
   </li>
 
   <li><strong>Join Our Discord Community</strong> – Connect with fellow developers, share ideas, and get support.
-    <a href="https://discord.gg/HAcGh8mfmj">Join Discord</a>
+    <a href="https://t.zip/discord?utm_source=github&utm_campaign=qul">Join Discord</a>
   </li>
 </ul>
 

--- a/app/views/user_mailer/thank_you.html.erb
+++ b/app/views/user_mailer/thank_you.html.erb
@@ -26,7 +26,7 @@
   </li>
 
   <li><strong>Join Our Discord Community</strong> – Connect with fellow developers, share ideas, and get support.
-    <a href="https://t.zip/discord?utm_source=github&utm_campaign=qul">Join Discord</a>
+    <a href="https://t.zip/discord?utm_source=thank%20you%20email&utm_campaign=qul">Join Discord</a>
   </li>
 </ul>
 

--- a/scripts/cypress-e2e/cypress/e2e/Pages/signupPage.js
+++ b/scripts/cypress-e2e/cypress/e2e/Pages/signupPage.js
@@ -33,10 +33,6 @@ class SIGNUP {
     cy.get(".qul-logo").should("be.visible");
     cy.get('a[href="/resources"]').should("contain.text", "Resources");
     cy.get('a[href="/tools"]').should("contain.text", "Tools");
-    cy.get('a[href="https://discord.gg/HAcGh8mfmj"]').should(
-      "contain.text",
-      "Community"
-    );
     cy.get('a[href="/faq"]').should("contain.text", "FAQ");
     cy.get(
       'a[href="https://github.com/TarteelAI/quranic-universal-library"]'


### PR DESCRIPTION
- Consolidate mismatched Discord invite links into https://t.zip/discord?utm_source=github&utm_campaign=qul.   
- Convert redundant link text declarations from `- TEXT: [LINK](LINK)` to `- [TEXT](LINK)`.
  
Related to #668
