### PR TITLE
fix: native bin/setup and bin/dev local (non-Docker) setup

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,9 @@
-QUL_STORAGE_ACCESS_KEY: "aws access key"
-QUL_STORAGE_ACCESS_KEY_SECRET: "aws key secret"
-QUL_STORAGE_BUCKET: "bucket name"
-QUL_STORAGE_PUBLIC_EXPORT: true
-QUL_STORAGE_ENDPOINT: "aws endpoint"
-QUL_STORAGE_REGION: "bucket region"
+# Leave these blank for local development - config/storage.yml falls back to
+# safe defaults (a "missing" bucket and a https://fix.me endpoint) when unset.
+# Only fill these in if you have real S3-compatible storage credentials.
+QUL_STORAGE_ACCESS_KEY=
+QUL_STORAGE_ACCESS_KEY_SECRET=
+QUL_STORAGE_BUCKET=
+QUL_STORAGE_PUBLIC_EXPORT=true
+QUL_STORAGE_ENDPOINT=
+QUL_STORAGE_REGION=

--- a/app/views/docs/markdown/project-setup.md
+++ b/app/views/docs/markdown/project-setup.md
@@ -19,7 +19,17 @@ cd quranic-universal-library
 bin/setup
 ```
 
-`bin/setup` installs Ruby and JavaScript dependencies, prepares the database, and runs initial setup steps.
+`bin/setup` installs gem and JavaScript dependencies and prepares the database.
+
+QUL uses two Postgres databases in development (see `config/database.yml`): a CMS database (users, drafts, versions) and a separate Quran content database, `quran_dev` (verses, words, translations, and most of the app's data). `bin/setup` creates both, but `quran_dev` starts out empty — it isn't seeded by migrations. To populate it, download and load the published data dump:
+
+```bash
+curl -L -o mini_quran_dev.sql.zip https://static-cdn.tarteel.ai/qul/mini-dumps/mini_quran_dev.sql.zip
+unzip mini_quran_dev.sql.zip
+psql -d quran_dev -f mini_quran_dev.sql
+```
+
+Until this is loaded, pages that touch Quran content (verses, words, translations, etc.) will raise errors.
 
 ## Run the App
 

--- a/bin/setup
+++ b/bin/setup
@@ -16,6 +16,7 @@ FileUtils.chdir APP_ROOT do
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
   system("bundle check") || system!("bundle install")
+  system! "yarn install"
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")
@@ -23,6 +24,11 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
+  # QUL connects to two separate Postgres databases (see config/database.yml):
+  # the CMS database (users, drafts, etc.) and the Quran content database
+  # (quran_dev in development). db:prepare only sets up the CMS database, so
+  # db:create:all is needed first to also create the Quran content database.
+  system! "bin/rails db:create:all"
   system! "bin/rails db:prepare"
 
   puts "\n== Removing old logs and tempfiles =="

--- a/lib/tasks/tailwindcss.rake
+++ b/lib/tasks/tailwindcss.rake
@@ -1,0 +1,19 @@
+# Overrides tailwindcss-rails' watch task to stop it exiting immediately under foreman (bin/dev).
+Rake::Task["tailwindcss:watch"].clear if Rake::Task.task_defined?("tailwindcss:watch")
+
+namespace :tailwindcss do
+  desc "Watch and build Tailwind CSS on file changes (stays alive under bin/dev)"
+  task watch: :environment do |_, args|
+    debug = args.extras.include?("debug")
+    poll = args.extras.include?("poll")
+    always = args.extras.include?("always")
+    command = Tailwindcss::Commands.watch_command(always: always, debug: debug, poll: poll)
+    puts command.inspect if args.extras.include?("verbose")
+
+    IO.popen(command, "r+") do |io|
+      IO.copy_stream(io, $stdout)
+    end
+  rescue Interrupt
+    puts "Received interrupt, exiting tailwindcss:watch" if args.extras.include?("verbose")
+  end
+end


### PR DESCRIPTION
## Summary

`bin/setup` reports success but leaves `bin/dev` unable to actually run. Three separate bugs, hit one after another:

1. `bin/setup` never runs `yarn install`, so `bin/dev` fails with `Cannot find module 'esbuild'`.
2. QUL uses two separate databases in development (`config/database.yml`) — the CMS database and a Quran content database (`quran_dev`, used by most models via `QuranApiRecord`). `bin/rails db:prepare` only sets up the CMS one. Even Rails' own suggested fix, `db:create`, misses it — only `db:create:all` creates it. This is the real cause of the "run migrate twice?" confusion in #366.
3. Even after fixing 1 and 2, `bin/dev` crashed ~1s after starting. `Procfile.dev`'s tailwind process inherits foreman's closed stdin, and the Tailwind CLI treats stdin EOF as "stop watching" and exits, which makes foreman kill `web` and `js` too. The `tailwindcss-rails` gem already fixes this for its Puma plugin using `IO.popen` instead of `system()` ([tailwindcss-rails#349](https://github.com/rails/tailwindcss-rails/pull/349)); this applies the same fix to the plain rake task `Procfile.dev` uses.

Verified from a clean state (no `quran_dev`, no `node_modules`, unmodified `.env.sample`) through to a running app with real Quran data loaded.

## What changed

- `bin/setup`: added `yarn install`, and `db:create:all` before `db:prepare`.
- `.env.sample`: placeholder values like `"aws endpoint"` are non-blank, so they defeat `config/storage.yml`'s `.presence || 'https://fix.me'` fallback and the app 500s on the first request. Changed to blank values so the existing fallback works.
- `lib/tasks/tailwindcss.rake` (new): overrides `tailwindcss:watch` to use `IO.popen` instead of `system()`, fixing the foreman crash.
- `app/views/docs/markdown/project-setup.md`: explains the two-database setup and links the data dump, so `/docs/project-setup` matches what `bin/setup` actually does now.

## Test plan

- [x] Reproduced all three failures from a clean state, then verified each fix resolves it.
- [x] `bin/setup` creates all three databases.
- [x] Loaded the published `mini_quran_dev.sql.zip` dump; confirmed real data (`Verse.count` => 1923).
- [x] `bin/dev` starts and all three processes stay running.
- [x] `curl http://127.0.0.1:3000/` returns `200`.
- [x] `curl http://127.0.0.1:3000/docs/project-setup` returns `200` and renders the updated content.

## PR Checklist

- [x] **Scope is clear and focused.** 4 files, each mapped to one reproduced failure or the docs gap it caused.
- [x] **Commands in docs were re-validated.** `bin/setup`/`bin/dev` re-run from a clean state after each fix, against the exact commands in https://qul.tarteel.ai/docs/project-setup; the updated docs page itself was rendered and checked via `/docs/project-setup`.
- [x] **New user onboarding path remains intact.** This PR fixes that exact path end-to-end, and the docs page now describes it accurately.
- [x] **Backward-compatible website docs behavior is preserved.** No unrelated docs pages touched; `project-setup.md` is updated to match the behavior this PR ships, not changed in tone or structure otherwise.

## Related

Closes #366
