### PR TITLE
Group ayah by page and render in order on Quran metadata pages 

### DIFF
--- a/app/models/hizb.rb
+++ b/app/models/hizb.rb
@@ -21,6 +21,6 @@ class Hizb < QuranApiRecord
   include NavigationSearchable
   include HasVerseMapping
 
-  has_many :verses, foreign_key: :manzil_number
+  has_many :verses, foreign_key: :hizb_number
   has_many :chapters, through: :verses
 end

--- a/app/views/resources/previews/quran_metadata/_hizb_preview.html.erb
+++ b/app/views/resources/previews/quran_metadata/_hizb_preview.html.erb
@@ -1,7 +1,13 @@
 <%
   id = (params[:hizb].presence || 1).to_i.abs
   hizb = Hizb.find_by(hizb_number: id) || Hizb.first
+  cache_key = ["hizb", hizb.id, params.to_unsafe_h]
 %>
+
+<% cache(cache_key, expires_in: 7.days) do %>
+  <%
+    verses_by_page = hizb.verses.includes(:chapter).order('verse_index ASC').group_by(&:page_number)
+  %>
 
 <div class="flex flex-wrap items-center justify-center gap-4 mb-6">
   <div class="flex items-center">
@@ -35,7 +41,8 @@
     <p class="mt-2 text-sm text-gray-600">Total Ayahs:
       <strong>
         <%= hizb.verses_count %>
-      </strong></p>
+      </strong>
+      | Pages: <strong><%= verses_by_page.keys.length %></strong></p>
   </div>
 
   <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-4">
@@ -44,15 +51,21 @@
     <p><strong>To:</strong> <%= hizb.last_verse.chapter.name_simple %>, Ayah <%= hizb.last_verse.verse_number %></p>
   </div>
 
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-    <h2 class="text-lg font-semibold mb-4">Surahs in this Hizb</h2>
-    <ul class="divide-y divide-gray-200">
-      <% hizb.verse_mapping.each do |chapter_id, verses_range| %>
-        <% chapter = Chapter.find(chapter_id) %>
-        <li class="py-2">
-          <span class="font-medium">Surah <%= chapter.name_simple %></span>: Ayahs <%= verses_range %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <% if verses_by_page.any? %>
+    <div class="overflow-y-auto border border-gray-200 rounded-lg shadow-sm bg-white" style="max-height: 1600px;">
+      <div class="flex flex-col gap-6 p-4">
+        <% verses_by_page.sort.each do |page_num, page_verses| %>
+          <div class="border-b pb-6 last:border-b-0">
+            <div class="text-sm font-semibold text-gray-700 mb-3">Page <%= page_num %></div>
+            <div class="qpc-hafs quran-text text-lg leading-relaxed">
+              <% page_verses.each do |verse| %>
+                <%= verse.text_qpc_hafs %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>
+<% end %>

--- a/app/views/resources/previews/quran_metadata/_juz_preview.html.erb
+++ b/app/views/resources/previews/quran_metadata/_juz_preview.html.erb
@@ -1,7 +1,13 @@
 <%
   id = (params[:juz].presence || 1).to_i.abs
   juz = Juz.find_by(juz_number: id) || Juz.first
+  cache_key = ["juz", juz.id, params.to_unsafe_h]
 %>
+
+<% cache(cache_key, expires_in: 7.days) do %>
+  <%
+    verses_by_page = juz.verses.includes(:chapter).order('verse_index ASC').group_by(&:page_number)
+  %>
 
 <div class="flex flex-wrap items-center justify-center gap-4 mb-6">
   <div class="flex items-center">
@@ -35,7 +41,8 @@
     <p class="mt-2 text-sm text-gray-600">Total Ayahs:
       <strong>
         <%= juz.verses_count %>
-      </strong></p>
+      </strong>
+      | Pages: <strong><%= verses_by_page.keys.length %></strong></p>
   </div>
 
   <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-4">
@@ -44,15 +51,21 @@
     <p><strong>To:</strong> <%= juz.last_verse.chapter.name_simple %>, Ayah <%= juz.last_verse.verse_number %></p>
   </div>
 
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-    <h2 class="text-lg font-semibold mb-4">Surahs in this Juz</h2>
-    <ul class="divide-y divide-gray-200">
-      <% juz.verse_mapping.each do |chapter_id, verses_range| %>
-        <% chapter = Chapter.find(chapter_id) %>
-        <li class="py-2">
-          <span class="font-medium">Surah <%= chapter.name_simple %></span>: Ayahs <%= verses_range %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <% if verses_by_page.any? %>
+    <div class="overflow-y-auto border border-gray-200 rounded-lg shadow-sm bg-white" style="max-height: 600px;">
+      <div class="flex flex-col gap-6 p-4">
+        <% verses_by_page.sort.each do |page_num, page_verses| %>
+          <div class="border-b pb-6 last:border-b-0">
+            <div class="text-sm font-semibold text-gray-700 mb-3">Page <%= page_num %></div>
+            <div class="qpc-hafs quran-text text-lg leading-relaxed">
+              <% page_verses.each do |verse| %>
+                <%= verse.text_qpc_hafs %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>
+<% end %>

--- a/app/views/resources/previews/quran_metadata/_manzil_preview.html.erb
+++ b/app/views/resources/previews/quran_metadata/_manzil_preview.html.erb
@@ -1,7 +1,13 @@
 <%
   id = (params[:manzil].presence || 1).to_i.abs
   manzil = Manzil.find_by(manzil_number: id) || Manzil.first
+  cache_key = ["manzil", manzil.id, params.to_unsafe_h]
 %>
+
+<% cache(cache_key, expires_in: 7.days) do %>
+  <%
+    verses_by_page = manzil.verses.includes(:chapter).order('verse_index ASC').group_by(&:page_number)
+  %>
 
 <div class="flex flex-wrap items-center justify-center gap-4 mb-6">
   <div class="flex items-center">
@@ -35,7 +41,8 @@
     <p class="mt-2 text-sm text-gray-600">Total Ayahs:
       <strong>
         <%= manzil.verses_count %>
-      </strong></p>
+      </strong>
+      | Pages: <strong><%= verses_by_page.keys.length %></strong></p>
   </div>
 
   <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-4">
@@ -44,15 +51,21 @@
     <p><strong>To:</strong> <%= manzil.last_verse.chapter.name_simple %>, Ayah <%= manzil.last_verse.verse_number %></p>
   </div>
 
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-    <h2 class="text-lg font-semibold mb-4">Surahs in this Manzil</h2>
-    <ul class="divide-y divide-gray-200">
-      <% manzil.verse_mapping.each do |chapter_id, verses_range| %>
-        <% chapter = Chapter.find(chapter_id) %>
-        <li class="py-2">
-          <span class="font-medium">Surah <%= chapter.name_simple %></span>: Ayahs <%= verses_range %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <% if verses_by_page.any? %>
+    <div class="overflow-y-auto border border-gray-200 rounded-lg shadow-sm bg-white" style="max-height: 600px;">
+      <div class="flex flex-col gap-6 p-4">
+        <% verses_by_page.sort.each do |page_num, page_verses| %>
+          <div class="border-b pb-6 last:border-b-0">
+            <div class="text-sm font-semibold text-gray-700 mb-3">Page <%= page_num %></div>
+            <div class="qpc-hafs quran-text text-lg leading-relaxed">
+              <% page_verses.each do |verse| %>
+                <%= verse.text_qpc_hafs %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>
+<% end %>

--- a/app/views/resources/previews/quran_metadata/_rub_preview.html.erb
+++ b/app/views/resources/previews/quran_metadata/_rub_preview.html.erb
@@ -1,7 +1,13 @@
 <%
   id = (params[:rub].presence || 1).to_i.abs
   rub = RubElHizb.find_by(rub_el_hizb_number: id) || RubElHizb.first
+  cache_key = ["rub", rub.id, params.to_unsafe_h]
 %>
+
+<% cache(cache_key, expires_in: 7.days) do %>
+  <%
+    verses_by_page = rub.verses.includes(:chapter).order('verse_index ASC').group_by(&:page_number)
+  %>
 
 <div class="flex flex-wrap items-center justify-center gap-4 mb-6">
   <div class="flex items-center">
@@ -35,7 +41,8 @@
     <p class="mt-2 text-sm text-gray-600">Total Ayahs:
       <strong>
         <%= rub.verses_count %>
-      </strong></p>
+      </strong>
+      | Pages: <strong><%= verses_by_page.keys.length %></strong></p>
   </div>
 
   <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-4">
@@ -44,15 +51,21 @@
     <p><strong>To:</strong> <%= rub.last_verse.chapter.name_simple %>, Ayah <%= rub.last_verse.verse_number %></p>
   </div>
 
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
-    <h2 class="text-lg font-semibold mb-4">Surahs in this Rub al-Hizb</h2>
-    <ul class="divide-y divide-gray-200">
-      <% rub.verse_mapping.each do |chapter_id, verses_range| %>
-        <% chapter = Chapter.find(chapter_id) %>
-        <li class="py-2">
-          <span class="font-medium">Surah <%= chapter.name_simple %></span>: Ayahs <%= verses_range %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
+  <% if verses_by_page.any? %>
+    <div class="overflow-y-auto border border-gray-200 rounded-lg shadow-sm bg-white" style="max-height: 600px;">
+      <div class="flex flex-col gap-6 p-4">
+        <% verses_by_page.sort.each do |page_num, page_verses| %>
+          <div class="border-b pb-6 last:border-b-0">
+            <div class="text-sm font-semibold text-gray-700 mb-3">Page <%= page_num %></div>
+            <div class="qpc-hafs quran-text text-lg leading-relaxed">
+              <% page_verses.each do |verse| %>
+                <%= verse.text_qpc_hafs %>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  <% end %>
 </div>
+<% end %>

--- a/app/views/resources/previews/quran_metadata/_ruku_preview.html.erb
+++ b/app/views/resources/previews/quran_metadata/_ruku_preview.html.erb
@@ -1,8 +1,13 @@
 <%
   id = (params[:ruku].presence || 1).to_i.abs
   ruku = Ruku.find_by(ruku_number: id) || Ruku.first
-  verses = ruku.verses
+  cache_key = ["ruku", ruku.id, params.to_unsafe_h]
 %>
+
+<% cache(cache_key, expires_in: 7.days) do %>
+  <%
+    verses_by_page = ruku.verses.includes(:chapter).order('verse_index ASC').group_by(&:page_number)
+  %>
 
 <div class="flex flex-wrap items-center justify-center gap-4 mb-6">
   <div class="flex items-center">
@@ -22,7 +27,7 @@
       <% end %>
     <% end %>
 
-    <% if ruku.ruku_number < 30 %>
+    <% if ruku.ruku_number < 558 %>
       <%= link_to detail_resources_path('quran-metadata', resource.id, ruku: ruku.ruku_number + 1), class: 'btn btn-secondary' do %>
         Next →
       <% end %>
@@ -36,7 +41,8 @@
     <p class="mt-2 text-sm text-gray-600">Total Ayahs:
       <strong>
         <%= ruku.verses_count %>
-      </strong></p>
+      </strong>
+      | Pages: <strong><%= verses_by_page.keys.length %></strong></p>
   </div>
 
   <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 mb-4">
@@ -45,13 +51,21 @@
     <p><strong>To:</strong> <%= ruku.last_verse.chapter.name_simple %>, Ayah <%= ruku.last_verse.verse_number %></p>
   </div>
 
-  <div class="bg-white border border-gray-200 rounded-lg shadow-sm mb-2">
-    <div class="p-6">
-      <div class="qpc-hafs quran-text">
-        <% verses.each do |verse| %>
-          <%= verse.text_qpc_hafs %>
+  <% if verses_by_page.any? %>
+    <div class="overflow-y-auto border border-gray-200 rounded-lg shadow-sm bg-white" style="max-height: 600px;">
+      <div class="flex flex-col gap-6 p-4">
+        <% verses_by_page.sort.each do |page_num, page_verses| %>
+          <div class="border-b pb-6 last:border-b-0">
+            <div class="text-sm font-semibold text-gray-700 mb-3">Page <%= page_num %></div>
+            <div class="qpc-hafs quran-text text-lg leading-relaxed">
+              <% page_verses.each do |verse| %>
+                <%= verse.text_qpc_hafs %>
+              <% end %>
+            </div>
+          </div>
         <% end %>
       </div>
     </div>
-  </div>
+  <% end %>
 </div>
+<% end %>

--- a/app/views/resources/previews/quran_metadata/_sajda_preview.html.erb
+++ b/app/views/resources/previews/quran_metadata/_sajda_preview.html.erb
@@ -1,5 +1,5 @@
 <%
-  verses = Verse.unscoped.order('sajdah_number asc').where.not(sajdah_number: nil)
+  verses = Verse.unscoped.order('sajdah_number ASC, verse_index ASC').where.not(sajdah_number: nil)
 %>
 
 <div class="space-y-6 text-gray-800 text-base leading-relaxed">

--- a/lib/importer/quran_enc.rb
+++ b/lib/importer/quran_enc.rb
@@ -421,7 +421,6 @@ module Importer
       spanish_mokhtasar: /^(\d*,)?\d+.(\s)?/, # 2:3-4
       english_hilali_khan: /\([A-Z]\.\d+(?::\d+)?\)/,
       ukrainian_yakubovych: /^\[[IVXLCDM]+\]/,
-      indonesian_affairs: /^\*?\d+\)/,
       bengali_zakaria: /^\[\p{N}+\]/,
       hausa_gummi: /^\*/,
       punjabi_arif: /^[\d\p{M}\s]*/,
@@ -449,7 +448,7 @@ module Importer
       tajik_khawaja: [/\(\d+\)/, /\d+[.]/],
       spanish_montada_eu: [/\[\d+\]/, /\[\d+\]/],
       indonesian_complex: [/\d+/, /\d+[.\s]/],
-      indonesian_affairs: [/\d+\)/, /(?<!\()\*?\b\d+\)/],
+      indonesian_affairs: [/\[\d+\]/, /\[\d+\]/],
       french_montada: [/\[\d+\]/, /\[\d+\]/],
       english_hilali_khan: [/\[\d+\]/, /\[\d+\]/],
       english_saheeh: [/\[\d+\]/, /\[\d+\]-/],

--- a/lib/importer/quran_enc.rb
+++ b/lib/importer/quran_enc.rb
@@ -1,5 +1,3 @@
-# i = Importer::QuranEnc.new
-# i.import 'dagbani_ghatubo'
 module Importer
   class QuranEnc < Base
     include Utils::StrongMemoize
@@ -335,11 +333,6 @@ module Importer
       translation
     end
 
-    def swahili_barawani(verse, resource, footnote_resource, quran_enc_key, data)
-      # this translation has footnote, but there is no footnote markers in translation.
-      create_translation_with_footnote(verse, resource, footnote_resource, quran_enc_key, data, report_foonote_issues: false)
-    end
-
     def parse_pashto_zakaria(verse, resource, footnote_resource, quran_enc_key, data)
       data['translation'] = data['translation'].sub(/\d+-\d+/, '')
 
@@ -501,12 +494,13 @@ module Importer
       ukrainian_yakubovych: [/\[[IVXLCDM]+\]/, /\[[IVXLCDM]+\]/],
       russian_aboadel: [/\[\d+\]/, /\[\d+\]/],
       romanian_project: [/\[\d+\]/, /\[\d+\]/],
-      swahili_rwwad: [/\[\d+\]/, /\[\d+\]/]
+      swahili_rwwad: [/\[\d+\]/, /\[\d+\]/],
+      oromo_rwwad: [/\[\d+\]/, /\[\d+\]/]
     }.freeze
 
     TRANSLATIONS_MAPPING = {
-      zulu_adel: {id: 1642},
-      oromo_rwwad: {id: 1640},
+      zulu_adel: { id: 1642 },
+      oromo_rwwad: { id: 1640 },
       uzbek_sadiq_latin: { id: 55 },
       dutch_center: { language: 118, name: 'Dutch Islamic Center', id: 942 },
       pashto_rwwad: { language: 132, name: 'Rowwad Translation Center', id: 943 },
@@ -647,6 +641,7 @@ module Importer
     }.freeze
 
     TRANSLATIONS_WITH_FOOTNOTES = [
+      'oromo_rwwad',
       'amharic_zain',
       'swahili_rwwad',
       'romanian_project',


### PR DESCRIPTION
Quran metadata pages(Juz, Hizb etc) are now render list of ayahs. They're group by page number and rendered in verse_index order.