### PR TITLE
docs: clarify that audio_url points at Tarteel's CDN and should be self-hosted for production

### DIFF
--- a/app/views/docs/markdown/downloading-data.md
+++ b/app/views/docs/markdown/downloading-data.md
@@ -56,10 +56,15 @@ puts data.first
 - For large datasets, prefer SQLite or PostgreSQL over in-memory JSON processing.
 - Cache frequently accessed verses/tafsir payloads.
 - Stream very large JSON files instead of loading full files into memory.
+- For exports that reference CDN-hosted assets (for example recitation `audio_url` files on
+  `audio-cdn.tarteel.ai`), download them once and serve them from your own storage or CDN.
+  Tarteel's CDN is shared infrastructure, not a guaranteed production dependency.
 
 ## Troubleshooting
 
 - Download is slow/fails: retry with a stable connection and verify file size after download.
+- `audio_url` or other CDN URLs fail at runtime: download the asset once and serve it from your
+  own hosting instead of hotlinking Tarteel's CDN.
 - Schema mismatch in your app: inspect fields first and map keys explicitly.
 - Encoding issues: ensure UTF-8 handling in runtime and database.
 - Memory issues on large files: prefer SQLite or stream JSON.

--- a/app/views/docs/markdown/tutorial-recitation-end-to-end.md
+++ b/app/views/docs/markdown/tutorial-recitation-end-to-end.md
@@ -64,6 +64,14 @@ Practical meaning:
 5. Build a minimal player loop.
 6. Test with at least one full surah.
 
+> **`audio_url` points at Tarteel's CDN.** In published recitation packages the `audio_url`
+> pointer references Tarteel's public CDN, for example
+> `https://audio-cdn.tarteel.ai/quran/surah/abdulBasit/murattal/mp3/001.mp3`.
+> These URLs are provided so the exported files can be located and validated, but the CDN is
+> shared infrastructure that QUL does not guarantee for third-party production traffic.
+> **Download the files and self-host them** (own storage or CDN) before wiring them into a
+> production app; do not hotlink `audio-cdn.tarteel.ai` at runtime.
+
 Starter integration snippet (JavaScript):
 
 ```javascript
@@ -190,6 +198,7 @@ setInterval(() => {
 Open an issue if you find:
 
 - Broken or inaccessible audio file links
+- `audio_url` CDN links used directly in production instead of downloaded and self-hosted
 - Segment/timestamp values that do not match audible recitation
 - Missing ayah mappings in downloaded files
 - Inconsistent reciter or package metadata


### PR DESCRIPTION
Documents the CDN behavior of the recitation export's `audio_url` field.

Background: [quranic-universal-library#691](https://github.com/TarteelAI/quranic-universal-library/issues/691) asks whether the CDN URLs shipped in the exports (e.g. `https://audio-cdn.tarteel.ai/quran/surah/abdulBasit/murattal/mp3/001.mp3`) are intended for direct runtime use. This PR makes the intended usage explicit in the docs: the URLs are provided for locating/validating the files, and integrators should download and self-host them for production traffic.

Changes:
- `app/views/docs/markdown/tutorial-recitation-end-to-end.md`: note next to the `audio_url` field about the CDN + self-hosting, and a matching entry in "When to Request Updates or Changes".
- `app/views/docs/markdown/downloading-data.md`: guidance in "Performance Tips" and a troubleshooting entry for CDN URL failures.

Closes #691