### PR TITLE
Don't close segment validation modal  

### DIFF
--- a/app/javascript/segments/components/Verse.vue
+++ b/app/javascript/segments/components/Verse.vue
@@ -54,34 +54,43 @@
             </button>
           </div>
 
-          <div class="max-h-[60vh] overflow-y-auto divide-y divide-gray-100">
-            <p v-if="issuesLoading" class="px-4 py-8 text-sm text-gray-500 text-center">
+          <ul class="max-h-[60vh] overflow-y-auto divide-y divide-gray-100">
+            <li v-if="issuesLoading" class="px-4 py-8 text-sm text-gray-500 text-center">
               Checking segments…
-            </p>
-            <p v-else-if="issuesError" class="px-4 py-8 text-sm text-red-600 text-center">
+            </li>
+            <li v-else-if="issuesError" class="px-4 py-8 text-sm text-red-600 text-center">
               Could not validate segments. Please try again.
-            </p>
-            <p v-else-if="!activeIssues.length" class="px-4 py-8 text-sm text-gray-500 text-center">
+            </li>
+            <li v-else-if="!activeIssues.length" class="px-4 py-8 text-sm text-gray-500 text-center">
               No issues found 🎉
-            </p>
-            <button
+            </li>
+            <li
                 v-for="issue in activeIssues"
                 :key="issue.key"
-                @click="goToIssue(issue.verse)"
-                class="w-full flex items-center justify-between gap-3 px-4 py-3 text-left hover:bg-gray-50"
+                class="px-4 py-3"
             >
-              <span class="flex items-center gap-2 text-sm text-gray-700">
-                <span
-                    class="px-1.5 py-0.5 text-[10px] font-semibold rounded-full uppercase"
-                    :class="issue.severity === 'major' ? 'bg-red-100 text-red-700' : 'bg-yellow-100 text-yellow-800'"
-                >
-                  {{ issue.severity }}
+              <div class="flex items-start justify-between gap-3">
+                <span class="flex items-start gap-2 text-sm text-gray-700">
+                  <span
+                      class="mt-0.5 px-1.5 py-0.5 text-[10px] font-semibold rounded-full uppercase"
+                      :class="issue.severity === 'major' ? 'bg-red-100 text-red-700' : 'bg-yellow-100 text-yellow-800'"
+                  >
+                    {{ issue.severity }}
+                  </span>
+                  <span>{{ issue.message }}</span>
                 </span>
-                {{ issue.message }}
-              </span>
-              <span class="text-xs font-medium text-blue-600 whitespace-nowrap">Ayah {{ issue.verse }} →</span>
-            </button>
-          </div>
+                <a
+                    href="#"
+                    @click.prevent="goToIssue(issue.verse)"
+                    class="text-xs font-medium text-blue-600 hover:text-blue-800 hover:underline whitespace-nowrap"
+                >View ayah {{ issue.verse }} →</a>
+              </div>
+              <p v-if="issue.suggestion" class="mt-1.5 ml-1 flex items-start gap-1.5 text-xs text-gray-600 bg-gray-50 rounded px-2 py-1.5">
+                <span class="shrink-0">💡</span>
+                <span><span class="font-semibold text-gray-700">Suggested fix:</span> {{ issue.suggestion }}</span>
+              </p>
+            </li>
+          </ul>
         </div>
       </div>
 
@@ -939,6 +948,7 @@ export default {
         key: `server-${index}`,
         severity: issue.severity === 'bg-danger' ? 'major' : 'minor',
         message: issue.text,
+        suggestion: issue.suggestion || null,
       }));
     },
     fileDurationIssue() {
@@ -971,7 +981,6 @@ export default {
     },
     goToIssue(verse) {
       this.$store.commit('CHANGE_AYAH', { to: verse });
-      this.showIssues = false;
     },
     mainVerseData(verse) {
       return this.segments[`${this.chapter}:${verse}`] || null;
@@ -1009,7 +1018,7 @@ export default {
         const nextAyahStart = (nextData && present(nextData.timestamp_from)) ? Number(nextData.timestamp_from) : null;
 
         const issue = this.detectAyahIssue(data, audioDuration, nextAyahStart);
-        if (issue) issues.push({ verse, key: `${verse}-${issues.length}`, severity: issue.severity, message: issue.message });
+        if (issue) issues.push({ verse, key: `${verse}-${issues.length}`, severity: issue.severity, message: issue.message, suggestion: issue.suggestion || null });
 
         // Trailing gap: audio runs well past the last ayah's end (unsegmented tail).
         if (verse === this.versesCount && audioDuration && present(data.timestamp_to)) {
@@ -1042,7 +1051,12 @@ export default {
       }
 
       if (nextAyahStart !== null && Number(data.timestamp_to) > nextAyahStart) {
-        return { severity: 'major', message: 'Overlaps the next ayah' };
+        const overlap = Number(data.timestamp_to) - nextAyahStart;
+        return {
+          severity: 'major',
+          message: `Ends at ${Number(data.timestamp_to)} which overlaps the next ayah starting at ${nextAyahStart}.`,
+          suggestion: `Overlap is ${overlap} ms. Reduce this ayah's end by ${overlap} ms (to ${nextAyahStart} ms), or push the next ayah's start later by ${overlap} ms (to ${Number(data.timestamp_to)} ms).`,
+        };
       }
 
       const segments = data.segments || [];
@@ -1061,7 +1075,12 @@ export default {
       if (nextAyahStart !== null) {
         const gap = nextAyahStart - Number(data.timestamp_to);
         if (gap > AYAH_GAP_THRESHOLD_MS) {
-          minor = { severity: 'minor', message: `Gap of ${(gap / 1000).toFixed(1)}s before the next ayah (max allowed is 2s)` };
+          const excess = gap - AYAH_GAP_THRESHOLD_MS;
+          minor = {
+            severity: 'minor',
+            message: `Gap of ${(gap / 1000).toFixed(1)}s before the next ayah (max allowed is 2s)`,
+            suggestion: `Silent gap is ${gap} ms — ${excess} ms over the 2000 ms limit. Extend this ayah's end later or move the next ayah's start earlier by at least ${excess} ms.`,
+          };
         }
       }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,13 +54,13 @@ class User < ApplicationRecord
             length: { maximum: 50 },
             format: { with: /\A[\p{L}\p{M}'\- ]+\z/u, message: 'contains invalid characters' }
 
-  has_many :user_projects
-  has_many :user_downloads
+  has_many :user_projects, dependent: :delete_all
+  has_many :user_downloads, dependent: :delete_all
 
   after_create :send_welcome_email
 
   enum :role, {
-    normal_user: 0, # default
+    normal_user: 0,
     super_admin: 1,
     admin: 2,
     moderator: 3,

--- a/app/services/audio/segment_validator.rb
+++ b/app/services/audio/segment_validator.rb
@@ -89,12 +89,16 @@ module Audio
 
       earliest_start = min_word_start(segment)
       if earliest_start && from > earliest_start
-        issues << issue(segment, "#{segment.verse_key} ayah starts at #{from} which is after its earliest word starting at #{earliest_start}.", 'bg-danger', 'ayah_timing')
+        diff = from - earliest_start
+        suggestion = "Move #{segment.verse_key} start earlier by #{diff} ms (from #{from} to #{earliest_start} ms) so the ayah starts on or before its first word."
+        issues << issue(segment, "#{segment.verse_key} ayah starts at #{from} which is after its earliest word starting at #{earliest_start}.", 'bg-danger', 'ayah_timing', suggestion: suggestion)
       end
 
       latest_end = max_word_end(segment)
       if latest_end && to < latest_end
-        issues << issue(segment, "#{segment.verse_key} ayah ends at #{to} which is before its latest word ending at #{latest_end}.", 'bg-warning', 'ayah_timing')
+        diff = latest_end - to
+        suggestion = "Extend #{segment.verse_key} end later by #{diff} ms (from #{to} to #{latest_end} ms) so the ayah covers its last word."
+        issues << issue(segment, "#{segment.verse_key} ayah ends at #{to} which is before its latest word ending at #{latest_end}.", 'bg-warning', 'ayah_timing', suggestion: suggestion)
       end
 
       issues
@@ -110,10 +114,14 @@ module Audio
       return [] if next_start.nil?
 
       if segment.timestamp_to > next_start
-        [issue(segment, "#{segment.verse_key} ends at #{segment.timestamp_to} which overlaps the next ayah #{next_ayah.verse_key} starting at #{next_start}.", 'bg-danger', 'ayah_overlap')]
+        overlap = segment.timestamp_to - next_start
+        suggestion = "Overlap is #{overlap} ms. Reduce #{segment.verse_key} end by #{overlap} ms (from #{segment.timestamp_to} to #{next_start} ms), or push #{next_ayah.verse_key} start later by #{overlap} ms (from #{next_start} to #{segment.timestamp_to} ms)."
+        [issue(segment, "#{segment.verse_key} ends at #{segment.timestamp_to} which overlaps the next ayah #{next_ayah.verse_key} starting at #{next_start}.", 'bg-danger', 'ayah_overlap', suggestion: suggestion)]
       elsif next_start - segment.timestamp_to > AYAH_GAP_THRESHOLD_MS
         gap = next_start - segment.timestamp_to
-        [issue(segment, "#{segment.verse_key} ends at #{segment.timestamp_to} but the next ayah #{next_ayah.verse_key} starts at #{next_start} — #{gap} ms gap (max allowed is #{AYAH_GAP_THRESHOLD_MS} ms).", 'bg-warning', 'ayah_gap')]
+        excess = gap - AYAH_GAP_THRESHOLD_MS
+        suggestion = "Silent gap is #{gap} ms — #{excess} ms over the #{AYAH_GAP_THRESHOLD_MS} ms limit. Extend #{segment.verse_key} end later or move #{next_ayah.verse_key} start earlier by at least #{excess} ms to close the gap."
+        [issue(segment, "#{segment.verse_key} ends at #{segment.timestamp_to} but the next ayah #{next_ayah.verse_key} starts at #{next_start} — #{gap} ms gap (max allowed is #{AYAH_GAP_THRESHOLD_MS} ms).", 'bg-warning', 'ayah_gap', suggestion: suggestion)]
       else
         []
       end
@@ -214,7 +222,8 @@ module Audio
         gap = duration - last_segment.timestamp_to
         next if gap <= TRAILING_GAP_THRESHOLD_MS
 
-        issues << issue(last_segment, "Audio file ##{audio_file_id} is #{duration} ms but the last segment (#{last_segment.verse_key}) ends at #{last_segment.timestamp_to} ms — #{gap} ms (#{(gap / 1000.0).round}s) of audio after the last ayah is unsegmented.", 'bg-danger', 'trailing_gap')
+        suggestion = "Extend #{last_segment.verse_key} end by #{gap} ms (from #{last_segment.timestamp_to} to #{duration} ms) to cover the tail, or trim the extra audio if it is silence."
+        issues << issue(last_segment, "Audio file ##{audio_file_id} is #{duration} ms but the last segment (#{last_segment.verse_key}) ends at #{last_segment.timestamp_to} ms — #{gap} ms (#{(gap / 1000.0).round}s) of audio after the last ayah is unsegmented.", 'bg-danger', 'trailing_gap', suggestion: suggestion)
       end
 
       issues
@@ -230,8 +239,10 @@ module Audio
       ends.max
     end
 
-    def issue(segment, text, severity, category)
-      { key: segment.verse_key, text: text, severity: severity, category: category }
+    def issue(segment, text, severity, category, suggestion: nil)
+      data = { key: segment.verse_key, text: text, severity: severity, category: category }
+      data[:suggestion] = suggestion if suggestion
+      data
     end
 
     def present?(value)

--- a/app/views/admin/_validate_segments.html.erb
+++ b/app/views/admin/_validate_segments.html.erb
@@ -54,6 +54,11 @@
 
                     <div class="ml-2 mr-auto">
                       <%= issue[:text] %>
+                      <% if issue[:suggestion].present? %>
+                        <div class="mt-1 text-xs text-gray-600 bg-gray-50 rounded px-2 py-1">
+                          💡 <span class="font-semibold text-gray-700">Suggested fix:</span> <%= issue[:suggestion] %>
+                        </div>
+                      <% end %>
                     </div>
 
                     <% if issue[:key] %>

--- a/lib/tasks/one_time.rake
+++ b/lib/tasks/one_time.rake
@@ -1,4 +1,139 @@
 namespace :one_time do
+  # lib/tasks/quran/find_similar_ayah_beginnings.rake
+
+  desc "Find consecutive ayahs with similar beginnings"
+  task find_similar_ayah_beginnings: :environment do
+    MIN_WORDS = 5
+
+    verses = Verse
+      .unscoped
+      .includes(:words)
+      .order('verse_index ASC')
+
+    matches = []
+
+    previous = nil
+
+    verses.each do |verse|
+      if previous &&
+         previous.chapter_id == verse.chapter_id &&
+         previous.verse_number + 1 == verse.verse_number
+
+        previous_words = previous.words.sort_by(&:position).map(&:text_imlaei_simple)
+        current_words  = verse.words.sort_by(&:position).map(&:text_imlaei_simple)
+
+        common = []
+
+        previous_words.zip(current_words).each do |a, b|
+          break unless a == b
+          common << a
+        end
+
+        if common.length >= MIN_WORDS
+          matches << {
+            length: common.length,
+            chapter: verse.chapter_id,
+            verse1: previous.verse_number,
+            verse2: verse.verse_number,
+            prefix: common.join(" "),
+            text1: previous.text_qpc_hafs,
+            text2: verse.text_qpc_hafs
+          }
+        end
+      end
+
+      previous = verse
+    end
+
+    matches.sort_by! { |m| -m[:length] }
+
+    html = <<~HTML
+      <!DOCTYPE html>
+      <html dir="rtl">
+      <head>
+        <meta charset="utf-8">
+        <title>Similar Consecutive Ayah Beginnings</title>
+
+        <style>
+          body {
+            font-family: "Scheherazade New", serif;
+            margin: 40px;
+            background: #fafafa;
+          }
+
+          table {
+            border-collapse: collapse;
+            width: 100%;
+          }
+
+          th, td {
+            border: 1px solid #ddd;
+            padding: 10px;
+            vertical-align: top;
+          }
+
+          th {
+            background: #eee;
+          }
+
+          .prefix {
+            color: #008000;
+            font-weight: bold;
+            font-size: 22px;
+          }
+
+          .ayah {
+            font-size: 24px;
+            line-height: 2;
+          }
+        </style>
+      </head>
+
+      <body>
+
+      <h1>Consecutive Ayahs With Matching Beginnings</h1>
+
+      <p>Total Matches: #{matches.count}</p>
+
+      <table>
+      <tr>
+        <th>#</th>
+        <th>Reference</th>
+        <th>Matching Words</th>
+        <th>Common Beginning</th>
+        <th>Ayah 1</th>
+        <th>Ayah 2</th>
+      </tr>
+    HTML
+
+    matches.each_with_index do |m, i|
+      html << <<~ROW
+        <tr>
+          <td>#{i + 1}</td>
+          <td>#{m[:chapter]}:#{m[:verse1]} → #{m[:chapter]}:#{m[:verse2]}</td>
+          <td>#{m[:length]}</td>
+          <td class="prefix">#{m[:prefix]}</td>
+          <td class="ayah">#{m[:text1]}</td>
+          <td class="ayah">#{m[:text2]}</td>
+        </tr>
+      ROW
+    end
+
+    html << <<~HTML
+      </table>
+
+      </body>
+      </html>
+    HTML
+
+    output = Rails.root.join("tmp", "similar_ayah_beginnings.html")
+    File.write(output, html)
+
+    puts
+    puts "Found #{matches.count} matches"
+    puts "Exported to #{output}"
+  end
+
   task import_draft_translation: :environment do
     require 'csv'
     resource = ResourceContent.find(50)

--- a/test/services/audio/segment_validator_test.rb
+++ b/test/services/audio/segment_validator_test.rb
@@ -60,6 +60,19 @@ class SegmentValidatorTest < Minitest::Test
     assert_equal '32:1', overlap[:key]
   end
 
+  def test_overlap_suggestion_reports_the_difference_and_fix
+    segments = [
+      segment(verse: 1, from: 0, to: 5000),
+      segment(verse: 2, from: 4000, to: 8000)
+    ]
+    overlap = validate(segments).find { |issue| issue[:category] == 'ayah_overlap' }
+
+    refute_nil overlap[:suggestion]
+    assert_includes overlap[:suggestion], '1000 ms'
+    assert_includes overlap[:suggestion], 'Reduce 32:1 end'
+    assert_includes overlap[:suggestion], 'push 32:2 start'
+  end
+
   def test_gap_larger_than_threshold_is_warning
     segments = [
       segment(verse: 1, from: 0, to: 5000),


### PR DESCRIPTION
Segment validation modal was automatically closing when the user clicked on a listed issue. This created unnecessary friction, as users sometimes need to copy timing information or compare multiple issues before making changes. The modal now remains open when selecting an issue.