### PR TITLE
Fix indentation in font CSS example

### DIFF
--- a/app/views/resources/previews/_font.html.erb
+++ b/app/views/resources/previews/_font.html.erb
@@ -129,13 +129,11 @@
 
           <li>
             <strong>Define a <code>@font-face</code> Rule in Your CSS</strong>
-            <pre class="bg-gray-100 rounded p-4 overflow-auto text-sm"><code>
-              @font-face {
+            <pre class="bg-gray-100 rounded p-4 overflow-auto text-sm"><code>@font-face {
   font-family: '<%= font_face %>';
   src: url('<%= font_url %>') format('<%= font_format == 'woff2' ? 'woff2' : font_format == 'woff' ? 'woff' : font_format == 'otf' ? 'opentype' : 'truetype' %>');
   font-display: swap;
-}
-            </code></pre>
+}</code></pre>
           </li>
 
           <li>


### PR DESCRIPTION
## Description

Removes the extra whitespace around the `@font-face` code example so it displays and copies with the expected indentation.

## Related Issue

Fixes #687

## Motivation and Context

The `<pre>` element preserves whitespace, so the line breaks and source indentation inside the `<code>` tag appear in the rendered example.

## How Has This Been Tested?

Checked the updated markup against the example in #687. The code block now starts with `@font-face {`, keeps each CSS property indented by two spaces, and ends directly after the closing brace. The change only affects the example shown on font resource pages.